### PR TITLE
Add count_fds() API as part of the task API

### DIFF
--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -17,6 +17,7 @@
 #ifndef PFS_TASK_HPP
 #define PFS_TASK_HPP
 
+#include <stddef.h>
 #include <set>
 #include <string>
 #include <vector>
@@ -57,6 +58,8 @@ public: // Getters
     get_environ(size_t max_size = 65536) const;
 
     std::string get_exe() const;
+
+    size_t count_fds() const;
 
     std::unordered_map<int, fd> get_fds() const;
 

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -17,6 +17,7 @@
 #ifndef PFS_UTILS_HPP
 #define PFS_UTILS_HPP
 
+#include <stddef.h>
 #include <fcntl.h>
 
 #include <limits>
@@ -81,6 +82,10 @@ stot(const std::string& str, T& out, base b = base::decimal)
 
     out = static_cast<T>(temp);
 }
+
+// Count all the files under the specified directory.
+// File can be any unix file type, i.e. regular file, directory, link, etc.
+size_t count_files(const std::string& dir, bool include_dots = false);
 
 // Get a set of all the files under the specified directory.
 // File can be any unix file type, i.e. regular file, directory, link, etc.

--- a/sample/enum_fd.cpp
+++ b/sample/enum_fd.cpp
@@ -54,7 +54,7 @@ void enum_task_fds(const pfs::task& task)
 {
     try
     {
-        LOG("fds");
+        LOG("fds (total: " << task.count_fds() << ")");
         LOG("---");
 
         auto sockets = enum_sockets(task.get_net());

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+#include <stddef.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <linux/limits.h>
@@ -341,6 +342,14 @@ std::vector<mount> task::get_mountinfo() const
     parsers::parse_lines(path, std::back_inserter(output),
                          parsers::parse_mountinfo_line);
     return output;
+}
+
+size_t task::count_fds() const
+{
+    static const std::string FDS_DIR("fd/");
+    auto path = _task_root + FDS_DIR;
+
+    return utils::count_files(path);
 }
 
 std::unordered_map<int, fd> task::get_fds() const


### PR DESCRIPTION
The current get_fds() API allows obtaining the process's number
of opened file descriptors, however, it forces saving extra temporary
information. The new count_fds() API could be useful in case of
processes with a large number of fds (ex: massive fd leakage).