### PR TITLE
Refactor namespace inode resolution

### DIFF
--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -71,6 +71,8 @@ public: // Getters
 
     net get_net() const;
 
+    ino_t get_ns(const std::string& ns) const;
+
     std::unordered_map<std::string, ino_t> get_ns() const;
 
     std::string get_root() const;

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -105,6 +105,11 @@ std::set<std::string> enumerate_files(const std::string& dir,
 // etc.
 std::set<int> enumerate_numeric_files(const std::string& dir);
 
+// Get the inode number of the file.
+// If the linkname is relative, then it is interpreted relative to the directory
+// referred to by the file descriptor dirfd.
+ino_t get_inode(const std::string& path, int dirfd = AT_FDCWD);
+
 // Return the path to which the specified link points.
 // If the linkname is relative, then it is interpreted relative to the directory
 // referred to by the file descriptor dirfd.

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -370,6 +370,14 @@ net task::get_net() const
     return net(_procfs_root);
 }
 
+ino_t task::get_ns(const std::string& ns) const
+{
+    static const std::string NS_DIR("ns/");
+    auto path = _task_root + NS_DIR + ns;
+
+    return utils::get_inode(path);
+}
+
 std::unordered_map<std::string, ino_t> task::get_ns() const
 {
     static const std::string NS_DIR("ns/");
@@ -388,15 +396,7 @@ std::unordered_map<std::string, ino_t> task::get_ns() const
     for (const auto& file :
          utils::enumerate_files(path, /* include_dots */ false))
     {
-        std::string link = utils::readlink(file, dirfd);
-
-        ino_t inode;
-        if (std::sscanf(link.c_str(), "%*[^:]:[%" PRIuMAX "]", &inode) != 1)
-        {
-            throw parser_error("Couldn't parse ns link", link);
-        }
-
-        ns.emplace(file, inode);
+        ns.emplace(file, utils::get_inode(file, dirfd));
     }
 
     return ns;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -100,6 +100,19 @@ std::set<int> enumerate_numeric_files(const std::string& dir)
     return files;
 }
 
+ino_t get_inode(const std::string& path, int dirfd)
+{
+    struct stat st;
+    int err = fstatat(dirfd, path.c_str(), &st, 0);
+    if (err)
+    {
+        throw std::system_error(errno, std::system_category(),
+                                "Couldn't stat file for inode");
+    }
+
+    return st.st_ino;
+}
+
 std::string readlink(const std::string& link, int dirfd)
 {
     std::string buffer;


### PR DESCRIPTION
- Allow resolution of a single namespace inode.
- Use stat for resolution (instead of readlinkat) to avoid string
  parsing and optimize access.