### PR TITLE
Use steady_clock::duration instead of double in uptime

### DIFF
--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <chrono>
 
 namespace pfs {
 
@@ -345,8 +346,8 @@ struct module
 
 struct uptime
 {
-    double system_time;
-    double idle_time;
+    std::chrono::steady_clock::duration system_time;
+    std::chrono::steady_clock::duration idle_time;
 };
 
 struct load_average

--- a/sample/format.hpp
+++ b/sample/format.hpp
@@ -582,8 +582,15 @@ inline std::ostream& operator<<(std::ostream& out,
 inline std::ostream& operator<<(std::ostream& out,
                                 const pfs::uptime& uptime)
 {
-    out << "system_time[" << uptime.system_time << "] ";
-    out << "idle_time[" << uptime.idle_time << "] ";
+    auto system_time_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+        uptime.system_time
+    ).count();
+    out << "system_time[" << system_time_seconds << "s] ";
+
+    auto idle_time_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+        uptime.idle_time
+    ).count();
+    out << "idle_time[" << idle_time_seconds << "s] ";
     return out;
 }
 

--- a/src/parsers/uptime.cpp
+++ b/src/parsers/uptime.cpp
@@ -45,8 +45,18 @@ uptime parse_uptime_line(const std::string& line)
     {
         uptime system_uptime;
 
-        system_uptime.system_time  = std::stod(tokens[SYSTEM_TIME]);
-        system_uptime.idle_time  = std::stod(tokens[IDLE_TIME]);
+        double system_time;
+        double idle_time;
+
+        system_time = std::stod(tokens[SYSTEM_TIME]);
+        idle_time = std::stod(tokens[IDLE_TIME]);
+
+        system_uptime.system_time = std::chrono::duration_cast<
+            std::chrono::steady_clock::duration
+        >(std::chrono::duration<double>(system_time));
+        system_uptime.idle_time = std::chrono::duration_cast<
+            std::chrono::steady_clock::duration
+        >(std::chrono::duration<double>(idle_time));
 
         return system_uptime;
     }

--- a/test/uptime.cpp
+++ b/test/uptime.cpp
@@ -1,5 +1,7 @@
 #include "catch.hpp"
 
+#include <chrono>
+
 #include "pfs/parsers.hpp"
 
 using namespace pfs::impl::parsers;
@@ -12,9 +14,12 @@ TEST_CASE("Parse uptime", "[procfs][uptime]")
     SECTION("Sample 1")
     {
         line = "523340.48 2063904.01";
-
-        expected.system_time       = 523340.48;
-        expected.idle_time          = 2063904.01;
+        expected.system_time = std::chrono::duration_cast<
+            std::chrono::steady_clock::duration
+        >(std::chrono::duration<double>(523340.48));
+        expected.idle_time = std::chrono::duration_cast<
+            std::chrono::steady_clock::duration
+        >(std::chrono::duration<double>(2063904.01));
     }
 
     auto uptime = parse_uptime_line(line);


### PR DESCRIPTION
Upgrade the uptime struct to hold steady_clock::duration instead
of doubles for time values.