### PR TITLE
Enhancement/move delim and remap into parser

### DIFF
--- a/include/pfs/parsers.hpp
+++ b/include/pfs/parsers.hpp
@@ -200,11 +200,11 @@ private:
 class status_parser : public file_parser<task_status>
 {
 public:
-    status_parser(const char delim) : file_parser<task_status>(delim, parsers)
-    {}
+    status_parser() : file_parser<task_status>(DELIM, PARSERS) {}
 
 private:
-    static const value_parsers parsers;
+    static const char DELIM;
+    static const value_parsers PARSERS;
 };
 
 // A parser of the /proc/stat file.

--- a/include/pfs/parsers.hpp
+++ b/include/pfs/parsers.hpp
@@ -211,12 +211,14 @@ private:
 class proc_stat_parser : public file_parser<proc_stat>
 {
 public:
-    proc_stat_parser(const char delim, remap_function key_remap)
-        : file_parser<proc_stat>(delim, parsers, key_remap)
-    {}
+    proc_stat_parser() : file_parser<proc_stat>(DELIM, PARSERS, key_remap) {}
 
 private:
-    static const value_parsers parsers;
+    static void key_remap(std::string& key);
+
+private:
+    static const char DELIM;
+    static const value_parsers PARSERS;
 };
 
 } // namespace parsers

--- a/src/parsers/proc_stat.cpp
+++ b/src/parsers/proc_stat.cpp
@@ -176,8 +176,22 @@ static void parse_softirq(const std::string& value, proc_stat& out)
 
 } // anonymous namespace
 
+const char proc_stat_parser::DELIM = ' ';
+
+void proc_stat_parser::key_remap(std::string& key)
+{
+    if (key == "cpu")
+    {
+        key = "cpu_total";
+    }
+    else if (key.rfind("cpu", 0) == 0)
+    {
+        key = "cpu_single";
+    }
+}
+
 // clang-format off
-const proc_stat_parser::value_parsers proc_stat_parser::parsers = {
+const proc_stat_parser::value_parsers proc_stat_parser::PARSERS = {
     { "cpu_total", parse_cpu_total },
     { "cpu_single", parse_cpu_single },
     { "intr", parse_intr },

--- a/src/parsers/status.cpp
+++ b/src/parsers/status.cpp
@@ -470,8 +470,10 @@ void parse_nonvoluntary_ctx_switches(const std::string& value, task_status& out)
 
 } // anonymous namespace
 
+const char status_parser::DELIM = ':';
+
 // clang-format off
-const status_parser::value_parsers status_parser::parsers = {
+const status_parser::value_parsers status_parser::PARSERS = {
     { "Name", parse_name },
     { "Umask", parse_umask },
     { "State", parse_state },

--- a/src/procfs.cpp
+++ b/src/procfs.cpp
@@ -139,22 +139,10 @@ uptime procfs::get_uptime() const
 
 proc_stat procfs::get_stat() const
 {
-    static constexpr char DELIM = ' ';
     static const std::string STATUS_FILE("stat");
     auto path = _root + STATUS_FILE;
 
-    auto key_remap = [&](std::string& key) -> void {
-        if (key == "cpu")
-        {
-            key = "cpu_total";
-        }
-        else if (key.rfind("cpu", 0) == 0)
-        {
-            key = "cpu_single";
-        }
-    };
-
-    return parsers::proc_stat_parser(DELIM, key_remap).parse(path);
+    return parsers::proc_stat_parser().parse(path);
 }
 
 std::vector<module> procfs::get_modules() const

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -14,14 +14,14 @@
  *  limitations under the License.
  */
 
-#include <stddef.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <linux/limits.h>
+#include <stddef.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #include <fstream>
 #include <iostream>
@@ -308,11 +308,10 @@ mem_stats task::get_statm() const
 
 task_status task::get_status(const std::set<std::string>& keys) const
 {
-    static constexpr char DELIM = ':';
     static const std::string STATUS_FILE("status");
     auto path = _task_root + STATUS_FILE;
 
-    return parsers::status_parser(DELIM).parse(path, keys);
+    return parsers::status_parser().parse(path, keys);
 }
 
 std::vector<mem_region> task::get_maps() const

--- a/test/status.cpp
+++ b/test/status.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Parse status", "[task][status]")
     std::string file = create_temp_file(content);
     pfs::impl::defer unlink_temp_file([&file] { unlink(file.c_str()); });
 
-    status_parser parser(':');
+    status_parser parser;
 
     SECTION("Parse all")
     {


### PR DESCRIPTION
Move constant values that are relevant to the specific parser into the class instead of passing it to them.
Caller should not care about those values at all.