### PR TITLE
Fix unknown type loff_t

### DIFF
--- a/include/pfs/mem.hpp
+++ b/include/pfs/mem.hpp
@@ -17,6 +17,9 @@
 #ifndef PFS_MEM_HPP
 #define PFS_MEM_HPP
 
+#include <fcntl.h>
+#include <sys/types.h>
+
 #include <string>
 #include <vector>
 

--- a/src/mem.cpp
+++ b/src/mem.cpp
@@ -14,9 +14,7 @@
  *  limitations under the License.
  */
 
-#include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This fixes #13 
Modules that included mem.hpp encountered an error: `loff_t` type is unknown
Because the relevant include was included from the source file.