### PR TITLE
Allow thread specific access

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,31 @@ That's it, you are good to go.
 
 ## Notes
 
+### General notes
+
 - All APIs and function calls might throw `std::bad_alloc` exceptions when allocations of standard containers such as `std::string` fail.
 - APIs are thread-safe. There are no internal states/members/caches that might be affected by simultaneous calls.
 - Objects do NOT handle data caching. All the APIs are pure getters that always(!) fetch the information from the filesystem.
 - The location of the procfs filesystem is configurable. Just create the `procfs` object with the right path for your machine.
+
+### Accessing inexisting tasks
+
+If you call `procfs().get_task(<id>)` and that task doesn't really exist, the constructor will succeed.
+
+Since tasks can die any time, instead of adding some extra validation during construction, that might be confusing, the current design assumes the first call after the tasks died will fail.
+
+### Collecting thread information
+
+There are two ways to collect information about a thread:
+1. `/proc/<tid>`
+1. `/proc/<pid>/task/<tid>`
+And the amazing fact is that they MIGHT provide different information.
+
+For example, when accessing using the first path, the `utime` and `stime` values under `stat` represent the amount of time scheduled for the entire process(!), whereas when accessing using the second path, they represent the amount of time scheduled for that thread only.
+
+How does that affect `pfs`?
+- When using `procfs().get_task(<id>)` you'll be accessing information using `/proc/<tid>`.
+- When using `my_task.get_task(<id>)` OR `my_task.get_tasks()` you'll be accessing information through `/proc/<pid>/task<tid>`
 
 ## Samples
 

--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -85,6 +85,8 @@ public: // Getters
 
     task_status get_status(const std::set<std::string>& keys = {}) const;
 
+    task get_task(int id) const;
+
     std::set<task> get_tasks() const;
 
 private:

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -413,6 +413,16 @@ std::unordered_map<std::string, ino_t> task::get_ns() const
     return ns;
 }
 
+task task::get_task(int id) const
+{
+    static const std::string TASKS_DIR("task/");
+    auto path = _task_root + TASKS_DIR;
+
+    // Important, see README note about collecting information
+    // about threads to understand why we pass 'path' as the root dir.
+    return task(path, id);
+}
+
 std::set<task> task::get_tasks() const
 {
     static const std::string TASKS_DIR("task/");
@@ -422,7 +432,9 @@ std::set<task> task::get_tasks() const
 
     for (auto thread_id : utils::enumerate_numeric_files(path))
     {
-        threads.emplace(task(_procfs_root, thread_id));
+        // Important, see README note about collecting information
+        // about threads to understand why we pass 'path' as the root dir.
+        threads.emplace(task(path, thread_id));
     }
 
     return threads;


### PR DESCRIPTION
Allow users of the library access both process-global and
thread-specific parameters.
See README for more information.