### PR TITLE
Fix task status ns_xxxx type and parsing

### DIFF
--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -245,10 +245,10 @@ struct task_status
     uid_set gid;
     size_t fd_size = 0;
     std::set<uid_t> groups;
-    int ns_tgid                     = INVALID_PID;
-    int ns_pid                      = INVALID_PID;
-    int ns_pgid                     = INVALID_PID;
-    int ns_sid                      = INVALID_PID;
+    std::vector<pid_t> ns_tgid;
+    std::vector<pid_t> ns_pid;
+    std::vector<pid_t> ns_pgid;
+    std::vector<pid_t> ns_sid;
     size_t vm_peak                  = 0; // In kB
     size_t vm_size                  = 0; // In kB
     size_t vm_lck                   = 0; // In kB

--- a/sample/format.hpp
+++ b/sample/format.hpp
@@ -380,10 +380,10 @@ inline std::ostream& operator<<(std::ostream& out, const pfs::task_status& st)
     out << "gid[" << st.gid << "] ";
     out << "fdsize[" << st.fd_size << "] ";
     out << "groups[" << join(st.groups) << "] ";
-    out << "ns_tgid[" << st.tgid << "] ";
-    out << "ns_pid[" << st.pid << "] ";
-    out << "ns_pgid[" << st.ns_pgid << "] ";
-    out << "ns_sid[" << st.ns_sid << "] ";
+    out << "ns_tgid[" << join(st.ns_tgid) << "] ";
+    out << "ns_pid[" << join(st.ns_pid) << "] ";
+    out << "ns_pgid[" << join(st.ns_pgid) << "] ";
+    out << "ns_sid[" << join(st.ns_sid) << "] ";
     out << "vm_peak[" << st.vm_peak << "] ";
     out << "vm_size[" << st.vm_size << "] ";
     out << "vm_lck[" << st.vm_lck << "] ";

--- a/src/parsers/status.cpp
+++ b/src/parsers/status.cpp
@@ -178,24 +178,45 @@ void parse_groups(const std::string& value, task_status& out)
     }
 }
 
+void to_ns_ids_vector(const std::string& value, std::vector<pid_t>& out)
+{
+    try
+    {
+        auto tokens = utils::split(value);
+        for (const auto& token : tokens)
+        {
+            pid_t id;
+            utils::stot(token, id);
+            out.push_back(id);
+        }
+    }
+    catch (const std::invalid_argument& ex)
+    {
+        throw parser_error("Corrupted id - Invalid argument", value);
+    }
+    catch (const std::out_of_range& ex)
+    {
+        throw parser_error("Corrupted id - Out of range", value);
+    }
+}
 void parse_ns_tgid(const std::string& value, task_status& out)
 {
-    to_number(value, out.ns_tgid);
+    to_ns_ids_vector(value, out.ns_tgid);
 }
 
 void parse_ns_pid(const std::string& value, task_status& out)
 {
-    to_number(value, out.ns_pid);
+    to_ns_ids_vector(value, out.ns_pid);
 }
 
 void parse_ns_pgid(const std::string& value, task_status& out)
 {
-    to_number(value, out.ns_pgid);
+    to_ns_ids_vector(value, out.ns_pgid);
 }
 
 void parse_ns_sid(const std::string& value, task_status& out)
 {
-    to_number(value, out.ns_sid);
+    to_ns_ids_vector(value, out.ns_sid);
 }
 
 void to_memory_size(const std::string& value, size_t& out)

--- a/test/status.cpp
+++ b/test/status.cpp
@@ -23,10 +23,10 @@ TEST_CASE("Parse status", "[task][status]")
         "Gid:    1000\t1000\t1000\t1000",
         "FDSize: 256",
         "Groups: 4 24 27",
-        "NStgid: 4481",
-        "NSpid:  4481",
-        "NSpgid: 4481",
-        "NSsid:  4481",
+        "NStgid: 4481 1",
+        "NSpid:  4481 1",
+        "NSpgid: 4481 1",
+        "NSsid:  4481 1",
         "VmPeak:    23848 kB",
         "VmSize:    23816 kB",
         "VmLck:         0 kB",
@@ -92,11 +92,11 @@ TEST_CASE("Parse status", "[task][status]")
         REQUIRE(status.gid.saved_set == 1000);
         REQUIRE(status.gid.filesystem == 1000);
         REQUIRE(status.fd_size == 256);
-        REQUIRE(status.groups == std::set<uid_t>({4, 24, 27}));
-        REQUIRE(status.ns_tgid == 4481);
-        REQUIRE(status.ns_pid == 4481);
-        REQUIRE(status.ns_pgid == 4481);
-        REQUIRE(status.ns_sid == 4481);
+        REQUIRE(status.groups == std::set<uid_t>{4, 24, 27});
+        REQUIRE(status.ns_tgid == std::vector<pid_t>{4481, 1});
+        REQUIRE(status.ns_pid == std::vector<pid_t>{4481, 1});
+        REQUIRE(status.ns_pgid == std::vector<pid_t>{4481, 1});
+        REQUIRE(status.ns_sid == std::vector<pid_t>{4481, 1});
         REQUIRE(status.vm_peak == 23848);
         REQUIRE(status.vm_size == 23816);
         REQUIRE(status.vm_lck == 0);
@@ -153,10 +153,10 @@ TEST_CASE("Parse status", "[task][status]")
         REQUIRE(status.gid == empty_uids);
         REQUIRE(status.fd_size == 0);
         REQUIRE(status.groups.empty());
-        REQUIRE(status.ns_tgid == pfs::INVALID_PID);
-        REQUIRE(status.ns_pid == pfs::INVALID_PID);
-        REQUIRE(status.ns_pgid == pfs::INVALID_PID);
-        REQUIRE(status.ns_sid == pfs::INVALID_PID);
+        REQUIRE(status.ns_tgid.empty());
+        REQUIRE(status.ns_pid.empty());
+        REQUIRE(status.ns_pgid.empty());
+        REQUIRE(status.ns_sid.empty());
         REQUIRE(status.vm_peak == 0);
         REQUIRE(status.vm_size == 0);
         REQUIRE(status.vm_lck == 0);


### PR DESCRIPTION
When running inside containers, these include multiple values,
one for every namespace.

We should parse a list out of this value.