### PR TITLE
Fix wrong member types in the proc_stat struct

### DIFF
--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -385,9 +385,9 @@ struct proc_stat
 
     sequence<cpu> cpus;
     sequence<unsigned long long> intr;
-    size_t ctxt;
+    unsigned long long ctxt;
     std::chrono::system_clock::time_point btime;
-    size_t processes;
+    unsigned long long processes;
     size_t procs_running;
     size_t procs_blocked;
     sequence<unsigned long long> softirq;


### PR DESCRIPTION
It appears that `ctxt` and `processes` members of the proc_stat
struct might exceed the size of unsigned int, fixing this bug
by using unsigned long long instead.