### PR TITLE
Adjust to compilation as CMake sub-directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,34 @@
 cmake_minimum_required (VERSION 3.5)
 
-project(pfs)
+project (pfs)
 
-option(BUILD_SHARED_LIBS "Build shared library (.so) instead of static one (.a)" ON)
-option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
-option(BUILD_SAMPLES "Build samples" ON)
-option(BUILD_TESTS "Build tests" ON)
+# ------------------------------------------------------------------------
+# Flags that are expected to be shared when added as sub-directory
+# ------------------------------------------------------------------------
+
+option (pfs_BUILD_SHARED_LIBS "Build a shared library instead of static one" ${BUILD_SHARED_LIBS})
+if (pfs_BUILD_SHARED_LIBS)
+    set (pfs_SHARED_OR_STATIC "SHARED")
+else ()
+    set (pfs_SHARED_OR_STATIC "STATIC")
+endif ()
 
 if (NOT CMAKE_BUILD_TYPE)
+    message (STATUS "Build type not specified. Set by default to DEBUG!")
     set (CMAKE_BUILD_TYPE Debug)
 endif ()
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
+# ------------------------------------------------------------------------
+# Flags that are NOT expected to be shared when added as sub-directory
+# ------------------------------------------------------------------------
+
+option (pfs_BUILD_ASAN "Enable address sanitizer" OFF)
+option (pfs_BUILD_SAMPLES "Build samples" ON)
+option (pfs_BUILD_TESTS "Build tests" ON)
+
+# ------------------------------------------------------------------------
+# Actual configuration
+# ------------------------------------------------------------------------
 
 add_compile_options (-std=c++11 -Wall -Wextra -pedantic -Werror)
 
@@ -20,29 +38,28 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-set (ROOT_SOURCE_DIR src)
-aux_source_directory (${ROOT_SOURCE_DIR} ROOT_SOURCES)
-aux_source_directory (${ROOT_SOURCE_DIR}/parsers PARSERS_SOURCES)
-set (SOURCES ${ROOT_SOURCES} ${PARSERS_SOURCES})
+set (pfs_ROOT_SOURCE_DIR src)
+aux_source_directory (${pfs_ROOT_SOURCE_DIR} pfs_ROOT_SOURCES)
+aux_source_directory (${pfs_ROOT_SOURCE_DIR}/parsers pfs_PARSERS_SOURCES)
+set (SOURCES ${pfs_ROOT_SOURCES} ${pfs_PARSERS_SOURCES})
 
-add_library (pfs ${SOURCES})
+add_library (pfs ${pfs_SHARED_OR_STATIC} ${SOURCES})
 
-if (ADDRESS_SANITIZER MATCHES ON)
-    message (STATUS "Enabling address sanitizer")
-    set (SANITIZE_FLAGS -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak)
-    target_compile_options (pfs PUBLIC ${SANITIZE_FLAGS})
-    target_link_libraries (pfs PUBLIC -lasan ${SANITIZE_FLAGS})
+if (pfs_BUILD_ASAN)
+    set (pfs_BUILD_ASAN_FLAGS -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak)
+    target_compile_options (pfs PUBLIC ${pfs_BUILD_ASAN_FLAGS})
+    target_link_libraries (pfs PUBLIC -lasan ${pfs_BUILD_ASAN_FLAGS})
 endif ()
 
-if (BUILD_SAMPLES)
-    aux_source_directory (sample SAMPLE_SOURCES)
-    add_executable (sample ${SAMPLE_SOURCES})
+if (pfs_BUILD_SAMPLES)
+    aux_source_directory (sample pfs_SAMPLE_SOURCES)
+    add_executable (sample ${pfs_SAMPLE_SOURCES})
     target_link_libraries (sample PRIVATE pfs)
 endif()
 
-if (BUILD_TESTS)
-    set (UNITTEST_SOURCE_DIR test)
-    aux_source_directory (${UNITTEST_SOURCE_DIR} UNITTEST_SOURCES)
-    add_executable (unittest ${UNITTEST_SOURCES})
+if (pfs_BUILD_TESTS)
+    set (pfs_UNITTEST_SOURCE_DIR test)
+    aux_source_directory (${pfs_UNITTEST_SOURCE_DIR} pfs_UNITTEST_SOURCES)
+    add_executable (unittest ${pfs_UNITTEST_SOURCES})
     target_link_libraries (unittest PRIVATE pfs)
 endif()

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ Very easy to use, procfs parsing library in C++.
 
 Run `cmake . && make`
 
-Currently supported CMake configuration flags:
+### Currently supported CMake configuration flags:
 
 - `CMAKE_BUILD_TYPE=<Debug|Release>`: Standard CMake flags to control build type (DEFAULT: Debug)
-- `BUILD_SHARED_LIBS=<ON|OFF>`: ON to compile a shared library. OFF to compile a static library (DEFAULT: ON)
-- `ENABLE_SANITIZER=<ON|OFF>`: ON to enable address sanitizer
-- `BUILD_SAMPLES=<ON|OFF>`: ON to build the sample programs
-- `BUILD_TESTS=<ON|OFF>`: ON to build the tests
+- `pfs_BUILD_SHARED_LIBS=<ON|OFF>`: ON to compile a shared library. OFF to compile a static library (DEFAULT: Inherit `BUILD_SHARE_LIBS`, which is `OFF` by default))
+- `pfs_BUILD_ASAN=<ON|OFF>`: ON to enable address sanitizer (DEFAULT: `OFF`)
+- `pfs_BUILD_SAMPLES=<ON|OFF>`: ON to build the sample programs (DEFAULT: `ON`)
+- `pfs_BUILD_TESTS=<ON|OFF>`: ON to build the tests (DEFAULT: `ON`)
 
 You can pass any number of those to the `cmake` command: `cmake -D<CONFIG_FLAG>=<VALUE> .`
+
+**NOTE**: After running `cmake` for the first time, some values are cached in `CMakeCache.txt` and will not change when running `cmake` for a second time with different flags.
 
 ### Build using clang
 


### PR DESCRIPTION
Avoid possible option collisions when using pfs as sub-directory. Some options are supposed to be shared with the project and are common CMake flags, like the `CMAKE_BUILD_TYPE` or `BUILD_SHARED_LIBS`. Whereas other flags are not supposed to be shared, and hence should are to be prefixed with the project name.

While at it, print all CMake options while building to ease debugging and standardize the formatting of the `CMakeLists.txt` file.