### PR TITLE
Add Parser for /proc/net/route

### DIFF
--- a/include/pfs/net.hpp
+++ b/include/pfs/net.hpp
@@ -58,6 +58,8 @@ public:
 
     std::vector<unix_socket> get_unix() const;
 
+    std::vector<net_route> get_route() const;
+
 private:
     friend class task;
     net(const std::string& procfs_root);

--- a/include/pfs/parsers.hpp
+++ b/include/pfs/parsers.hpp
@@ -83,6 +83,8 @@ id_map parse_id_map_line(const std::string& line);
 dev_t parse_device(const std::string& device_str);
 task_state parse_task_state(char state_char);
 
+net_route parse_net_route_line(const std::string& line);
+
 // When parsing key value text files, we might encounter different keys which
 // should be parsed in the same manner. To relate those lines in the same
 // manner, a remap function can be used.

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -604,6 +604,22 @@ struct id_map
     size_t length = UINT32_MAX;
 };
 
+// Hint: See 'fib_route_seq_show @ fib_trie.c'
+struct net_route
+{
+    std::string iface;
+    ip destination;
+    ip gateway;
+    unsigned int flags;
+    int refcnt;
+    unsigned int use;
+    int metric;
+    ip mask;
+    int mtu;
+    unsigned int window;
+    unsigned int irtt;
+};
+
 } // namespace pfs
 
 #endif // PFS_TYPES_HPP

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "pfs/types.hpp"
+
 namespace pfs {
 namespace impl {
 namespace utils {
@@ -151,6 +153,15 @@ void trim(std::string& str);
 
 // Ensure directory path is terminated using a directory separator '/'
 void ensure_dir_terminator(std::string& dir_path);
+
+// Parse IPv4 address in the hex form (e.g. 0x7f000001) and return it as a ip struct
+ip parse_ipv4_address(const std::string& ip_address_hex);
+
+// Parse IPv6 address in the hex form (e.g. 0x00000000000000000000000000000001) and return it as a ip struct
+ip parse_ipv6_address(const std::string& ip_address_hex);
+
+// Figure out ip version (IPv4/IPv6), parse it and return it as a ip struct
+std::pair<ip, uint16_t> parse_address(const std::string& address_str);
 
 } // namespace utils
 } // namespace impl

--- a/sample/enum_net.cpp
+++ b/sample/enum_net.cpp
@@ -71,6 +71,9 @@ int enum_net(std::vector<std::string>&& args)
 
         auto netlink = net.get_netlink();
         print(netlink);
+
+        auto routes = net.get_route();
+        print(routes);
     }
     catch (const std::runtime_error& ex)
     {

--- a/sample/format.hpp
+++ b/sample/format.hpp
@@ -709,3 +709,20 @@ inline std::ostream& operator<<(std::ostream& out, const pfs::cgroup& cg)
     out << "pathname[" << cg.pathname << "] ";
     return out;
 }
+
+inline std::ostream& operator<<(std::ostream& out, const pfs::net_route& route)
+{
+    out << "interface[" << route.iface << "] ";
+    out << "destination[" << route.destination.to_string() << "] ";
+    out << "gateway[" << route.gateway.to_string() << "] ";
+    out << "flags[" << route.flags << "] ";
+    out << "refcnt[" << route.refcnt << "] ";
+    out << "use[" << route.use << "] ";
+    out << "metric[" << route.metric << "] ";
+    out << "mask[" << route.mask.to_string() << "] ";
+    out << "mtu[" << route.mtu << "] ";
+    out << "window[" << route.window << "] ";
+    out << "irtt[" << route.irtt << "] ";
+
+    return out;
+}

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -142,4 +142,17 @@ std::vector<net_socket> net::get_net_sockets(const std::string& file) const
     return output;
 }
 
+std::vector<net_route> net::get_route() const
+{
+    static const size_t HEADER_LINES = 1;
+
+    static const std::string ROUTES_FILE("route");
+    auto path = _net_root + ROUTES_FILE;
+
+    std::vector<net_route> output;
+    parsers::parse_lines(path, std::back_inserter(output),
+                         parsers::parse_net_route_line, HEADER_LINES);
+    return output;
+}
+
 } // namespace pfs

--- a/src/parsers/route.cpp
+++ b/src/parsers/route.cpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2020-present Daniel Trugman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "pfs/parsers.hpp"
+#include "pfs/utils.hpp"
+#include "pfs/types.hpp"
+
+#include <set>
+#include <sstream>
+
+namespace pfs {
+namespace impl {
+namespace parsers {
+
+net_route parse_net_route_line(const std::string& line)
+{
+    // Some examples:
+    // clang-format off
+    // Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
+    // eth0    00000000        07030301        0003    0       0       0       00000000        0       0       0
+    // eth0    07030301        00000000        0001    0       0       0       00F0FFFF        0       0       0
+    // clang-format on
+
+    enum token
+    {
+        INTERFACE      = 0,
+        DESTINATION    = 1,
+        GATEWAY        = 2,
+        FLAGS          = 3,
+        REFCNT         = 4,
+        USE            = 5,
+        METRIC         = 6,
+        MASK           = 7,
+        MTU            = 8,
+        WINDOW         = 9,
+        IRTT           = 10,
+        COUNT
+    };
+
+    net_route route;
+
+    static const char DELIM = '\t';
+
+    auto tokens = utils::split(line, DELIM);
+    if (tokens.size() != COUNT)
+    {
+        throw parser_error("Corrupted net route - Unexpected tokens count", line);
+    }
+
+    // Parse tokens into route struct
+    route.iface = tokens[INTERFACE];
+    route.destination = utils::parse_ipv4_address(tokens[DESTINATION]);
+    route.gateway = utils::parse_ipv4_address(tokens[GATEWAY]);
+    route.mask = utils::parse_ipv4_address(tokens[MASK]);
+
+    utils::stot(tokens[FLAGS], route.flags, utils::base::hex);
+    utils::stot(tokens[REFCNT], route.refcnt, utils::base::decimal);
+    utils::stot(tokens[USE], route.use, utils::base::decimal);
+    utils::stot(tokens[METRIC], route.metric, utils::base::decimal);
+    utils::stot(tokens[MTU], route.mtu, utils::base::decimal);
+    utils::stot(tokens[WINDOW], route.window, utils::base::decimal);
+    utils::stot(tokens[IRTT], route.irtt, utils::base::decimal);
+
+    return route;
+}
+
+} // namespace parsers
+} // namespace impl
+} // namespace pfs

--- a/test/route.cpp
+++ b/test/route.cpp
@@ -1,0 +1,57 @@
+#include <sstream>
+
+#include "catch.hpp"
+#include "test_utils.hpp"
+
+#include "pfs/parsers.hpp"
+#include "pfs/types.hpp"
+
+using namespace pfs::impl::parsers;
+
+TEST_CASE("Parse corrupted route", "[net][route]")
+{
+    SECTION("Missing token")
+    {
+        std::string line = "eth0\t00000000\t012017AC\t0003\t0\t0\t0\t00000000\t0\t0";
+        REQUIRE_THROWS_AS(parse_net_route_line(line), pfs::parser_error);
+    }
+
+    SECTION("Extra token")
+    {
+        std::string line = "eth0\t00000000\t07030301\t0003\t0\t0\t0\t00000000\t0\t0\t0\t0";
+        REQUIRE_THROWS_AS(parse_net_route_line(line), pfs::parser_error);
+    }
+}
+
+TEST_CASE("Parse route", "[net][route]")
+{
+    pfs::net_route expected;
+
+    std::string line = "eth0\t00000000\t07030301\t0003\t0\t0\t0\t00F0FFFF\t0\t0\t0";
+
+    expected.iface       = "eth0";
+    expected.destination = pfs::ip(0x00000000);
+    expected.gateway     = pfs::ip(0x07030301);
+    expected.flags       = 0x0003;
+    expected.refcnt      = 0;
+    expected.use         = 0;
+    expected.metric      = 0;
+    expected.mask        = pfs::ip(0x00F0FFFF);
+    expected.mtu         = 0;
+    expected.window      = 0;
+    expected.irtt        = 0;
+ 
+    auto route = parse_net_route_line(line);
+
+    REQUIRE(route.iface == expected.iface);
+    REQUIRE(route.destination == expected.destination);
+    REQUIRE(route.gateway == expected.gateway);
+    REQUIRE(route.flags == expected.flags);
+    REQUIRE(route.refcnt == expected.refcnt);
+    REQUIRE(route.use == expected.use);
+    REQUIRE(route.metric == expected.metric);
+    REQUIRE(route.mask == expected.mask);
+    REQUIRE(route.mtu == expected.mtu);
+    REQUIRE(route.window == expected.window);
+    REQUIRE(route.irtt == expected.irtt);
+}


### PR DESCRIPTION
Working on a parser for IPv6 as well (it's a different file called `/proc/net/ipv6_route`)

Use pfs to get network device information from `/proc/net/route`. Adds parser, unit test, and sample out for new parser.