### PR TITLE
cmake: support find_package(pfs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,3 +63,17 @@ if (pfs_BUILD_TESTS)
     add_executable (unittest ${pfs_UNITTEST_SOURCES})
     target_link_libraries (unittest PRIVATE pfs)
 endif()
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CMAKE_PROJECT_NAME}-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+)
+
+install(TARGETS ${CMAKE_PROJECT_NAME} EXPORT ${CMAKE_PROJECT_NAME}Targets)
+install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+  FILE ${CMAKE_PROJECT_NAME}-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+)
+install(DIRECTORY include/ DESTINATION include)

--- a/cmake/pfs-config.cmake.in
+++ b/cmake/pfs-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/pfsTargets.cmake")
+check_required_components(pfs)


### PR DESCRIPTION
Adds a CMake configuration file to make it possible for CMake-based projects to use `find_package` to consume this library.