### PR TITLE
Get the sockets for a single task

### DIFF
--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -73,6 +73,8 @@ public: // Getters
 
     net get_net() const;
 
+    std::vector<net_socket> get_net_sockets() const;
+
     ino_t get_ns(const std::string& ns) const;
 
     std::unordered_map<std::string, ino_t> get_ns() const;

--- a/sample/enum.hpp
+++ b/sample/enum.hpp
@@ -24,5 +24,6 @@ int enum_system(std::vector<std::string>&& args);
 int enum_net(std::vector<std::string>&& args);
 int enum_tasks(std::vector<std::string>&& args);
 int enum_fds(std::vector<std::string>&& args);
+int enum_sockets(std::vector<std::string>&& args);
 
 #endif // SAMPLE_ENUM_HPP

--- a/sample/enum_sockets.cpp
+++ b/sample/enum_sockets.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2020-present Daniel Trugman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "enum.hpp"
+#include "format.hpp"
+#include "log.hpp"
+
+#include "pfs/procfs.hpp"
+
+int enum_sockets(std::vector<std::string>&& args)
+{
+    pfs::procfs pfs;
+
+    if (args.empty())
+    {
+        LOG("Need process ID to list sockets for");
+        return 1;
+    }
+
+    auto id = std::stoi(args[0]);
+    pfs::task task = pfs.get_task(id);
+
+    LOG("Process " << task.get_exe() << "(" << id << ") has the following network sockets:");
+    LOG("Local                    Remote                State");
+    for(pfs::net_socket& socket : task.get_net_sockets()){
+        LOG(socket.local_ip.to_string() << ":" << socket.local_port << "  ->  " << socket.remote_ip.to_string() << ":" << socket.remote_port << "    " << socket.socket_net_state );
+    }
+
+    return 0;
+}

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -42,6 +42,7 @@ int main(int argc, char** argv)
             {command("tasks", "[task-id]...", "Enumerate running tasks", enum_tasks)},
             {command("fds", "[task-id]...", "Enumerate fds for a specific task", enum_fds)},
             {command("lsmod", "[filter]", "Enumerate all loaded modules that match the filter", tool_lsmod)},
+            {command("sockets", "task-id", "Enumerate the network sockets for a specified task", enum_sockets)}
         };
         // clang-format on
 

--- a/src/parsers/net_socket.cpp
+++ b/src/parsers/net_socket.cpp
@@ -25,8 +25,6 @@ namespace parsers {
 
 namespace {
 
-static const size_t HEX_BYTE_LEN = 8;
-
 net_socket::net_state parse_state(const std::string& state_str)
 {
     int state_int;


### PR DESCRIPTION
Add a function to get the network sockets for a single task.

Also add a sample application to get the network sockets for a single task, similar to how `netstat` works.

See: #38 