### PR TITLE
Remove explicit --std=c++11 compile-option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option (pfs_BUILD_TESTS "Build tests" ON)
 # Actual configuration
 # ------------------------------------------------------------------------
 
-add_compile_options (-std=c++11 -Wall -Wextra -pedantic -Werror)
+add_compile_options (-Wall -Wextra -pedantic -Werror)
 
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -43,6 +43,7 @@ aux_source_directory (${pfs_ROOT_SOURCE_DIR}/parsers pfs_PARSERS_SOURCES)
 set (SOURCES ${pfs_ROOT_SOURCES} ${pfs_PARSERS_SOURCES})
 
 add_library (pfs ${pfs_SHARED_OR_STATIC} ${SOURCES})
+target_compile_features(pfs PUBLIC cxx_std_11)
 target_include_directories(
     pfs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -64,6 +65,7 @@ endif ()
 if (pfs_BUILD_SAMPLES)
     aux_source_directory (sample pfs_SAMPLE_SOURCES)
     add_executable (sample ${pfs_SAMPLE_SOURCES})
+    target_compile_features(sample PUBLIC cxx_std_11)
     target_link_libraries (sample PRIVATE pfs)
 endif()
 
@@ -71,6 +73,7 @@ if (pfs_BUILD_TESTS)
     set (pfs_UNITTEST_SOURCE_DIR test)
     aux_source_directory (${pfs_UNITTEST_SOURCE_DIR} pfs_UNITTEST_SOURCES)
     add_executable (unittest ${pfs_UNITTEST_SOURCES})
+    target_compile_features(unittest PUBLIC cxx_std_11)
     target_link_libraries (unittest PRIVATE pfs)
 endif()
 

--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -59,7 +59,7 @@ public: // Getters
     std::unordered_map<std::string, std::string>
     get_environ(size_t max_size = 65536) const;
 
-    std::string get_exe() const;
+    std::string get_exe(bool resolve = true) const;
 
     size_t count_fds() const;
 

--- a/sample/enum_net.cpp
+++ b/sample/enum_net.cpp
@@ -35,7 +35,7 @@ int enum_net(std::vector<std::string>&& args)
 
         auto dev = net.get_dev();
         print(dev);
-        
+
         auto icmp = net.get_icmp();
         print(icmp);
 
@@ -66,8 +66,8 @@ int enum_net(std::vector<std::string>&& args)
         auto udplite6 = net.get_udplite6();
         print(udplite6);
 
-        auto unix = net.get_unix();
-        print(unix);
+        auto unix_ = net.get_unix();
+        print(unix_);
 
         auto netlink = net.get_netlink();
         print(netlink);

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -85,12 +85,12 @@ std::vector<cgroup> task::get_cgroups() const
     return output;
 }
 
-std::string task::get_exe() const
+std::string task::get_exe(bool resolve) const
 {
     static const std::string EXE_FILE("exe");
     auto path = _task_root + EXE_FILE;
 
-    return utils::readlink(path);
+    return resolve ? utils::readlink(path) : path;
 }
 
 std::string task::get_cwd() const

--- a/test/test_proc_stat.cpp
+++ b/test/test_proc_stat.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Parse stat", "[procfs][proc_stat]")
     SECTION("Validate softirq")
     {
         unsigned long long sum = std::accumulate(
-            stats.softirq.per_item.begin(), stats.softirq.per_item.end(), 0);
+            stats.softirq.per_item.begin(), stats.softirq.per_item.end(), 0ULL);
         REQUIRE(sum == stats.softirq.total);
     }
 }


### PR DESCRIPTION
Allow the user to specify their desired CMAKE_CXX_STANDARD and CMAKE_CXX_EXTENSIONS.