### PR TITLE
Account For Variable Columns In `/proc/buddyinfo`

### DIFF
--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -431,8 +431,7 @@ struct zone
     size_t node_id;
     std::string name;
 
-    static constexpr size_t CHUNKS_COUNT = 11;
-    std::array<size_t, CHUNKS_COUNT> chunks;
+    std::vector<size_t> chunks;
 
     bool operator<(const zone& rhs) const
     {

--- a/src/parsers/buddyinfo.cpp
+++ b/src/parsers/buddyinfo.cpp
@@ -37,15 +37,16 @@ zone parse_buddyinfo_line(const std::string& line)
         NODE_ID      = 1,
         ZONE_KEYWORD = 2,
         ZONE_NAME    = 3,
-        FIRST_CHUNK  = 4,
-        LAST_CHUNK   = 14,
-        COUNT
+        FIRST_CHUNK  = 4
     };
 
     static const char NODE_DELIM = ',';
 
     auto tokens = utils::split(line);
-    if (tokens.size() != COUNT)
+
+    // The number of chunks is variable, but we should always have at least the
+    // first four columns.
+    if (tokens.size() < FIRST_CHUNK)
     {
         throw parser_error("Corrupted buddyinfo - Unexpected tokens count",
                            line);
@@ -66,7 +67,15 @@ zone parse_buddyinfo_line(const std::string& line)
 
         zn.name = tokens[ZONE_NAME];
 
-        for (size_t i = 0; i < zn.chunks.size(); ++i)
+        // std::distance can be negative, but the conditional on line 46
+        // and the nature of the begin() and end() iterators means num_chunks
+        // should never be less than 0.
+        size_t num_chunks =
+            std::distance(tokens.begin() + FIRST_CHUNK, tokens.end());
+
+        zn.chunks.resize(num_chunks);
+
+        for (size_t i = 0; i < num_chunks; ++i)
         {
             utils::stot(tokens[FIRST_CHUNK + i], zn.chunks[i]);
         }

--- a/src/parsers/buddyinfo.cpp
+++ b/src/parsers/buddyinfo.cpp
@@ -67,11 +67,9 @@ zone parse_buddyinfo_line(const std::string& line)
 
         zn.name = tokens[ZONE_NAME];
 
-        // std::distance can be negative, but the conditional on line 46
-        // and the nature of the begin() and end() iterators means num_chunks
-        // should never be less than 0.
-        size_t num_chunks =
-            std::distance(tokens.begin() + FIRST_CHUNK, tokens.end());
+        // This line is protected from underflow thanks to the tokens size
+        // conditional above.
+        size_t num_chunks = tokens.size() - FIRST_CHUNK;
 
         zn.chunks.resize(num_chunks);
 

--- a/test/test_buddyinfo.cpp
+++ b/test/test_buddyinfo.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Parse buddyinfo", "[procfs][buddyinfo]")
     pfs::zone expected;
     std::string line;
 
-    SECTION("Sample 1")
+    SECTION("Default size - Sample 1")
     {
         line = "Node 0, zone  Normal   216   55  189  101   84   38   37  "
                " 27    5    3  587";
@@ -19,7 +19,7 @@ TEST_CASE("Parse buddyinfo", "[procfs][buddyinfo]")
         expected.chunks  = {216, 55, 189, 101, 84, 38, 37, 27, 5, 3, 587};
     }
 
-    SECTION("Sample 2")
+    SECTION("Default size - Sample 2")
     {
         line = "Node 1, zone     DMA     1    1    1    0    2    1    1  "
                "  0    1    1    3";
@@ -29,8 +29,7 @@ TEST_CASE("Parse buddyinfo", "[procfs][buddyinfo]")
         expected.chunks  = {1, 1, 1, 0, 2, 1, 1, 0, 1, 1, 3};
     }
 
-    // 9 chunks instead of the default of 11
-    SECTION("Sample 3")
+    SECTION("Custom size - Smaller than default")
     {
         line = "Node 0, zone  Normal   189  101   84   38   37  "
                " 27    5    3  587";

--- a/test/test_buddyinfo.cpp
+++ b/test/test_buddyinfo.cpp
@@ -29,6 +29,17 @@ TEST_CASE("Parse buddyinfo", "[procfs][buddyinfo]")
         expected.chunks  = {1, 1, 1, 0, 2, 1, 1, 0, 1, 1, 3};
     }
 
+    // 9 chunks instead of the default of 11
+    SECTION("Sample 3")
+    {
+        line = "Node 0, zone  Normal   189  101   84   38   37  "
+               " 27    5    3  587";
+
+        expected.node_id = 0;
+        expected.name    = "Normal";
+        expected.chunks  = {189, 101, 84, 38, 37, 27, 5, 3, 587};
+    }
+
     auto zone = parse_buddyinfo_line(line);
     REQUIRE(zone.node_id == expected.node_id);
     REQUIRE(zone.name == expected.name);


### PR DESCRIPTION
The number of chunks, and therefore the number of columns, in `/proc/buddyinfo` is dependent on the value of the `MAX_ORDER` macro, defined in [`linux/mmzone.h`](https://github.com/torvalds/linux/blob/v6.12/include/linux/mmzone.h#L30), which can be configured at compile time with the `CONFIG_ARCH_FORCE_MAX_ORDER` option. These changes modify the buddyinfo parser to allow for any number of chunks.