### PR TITLE
fix(package.xml): install ROS package xml file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,3 +119,8 @@ install(
     DIRECTORY include/
     DESTINATION include
 )
+
+install(
+    FILES package.xml
+    DESTINATION share/${PROJECT_NAME}
+)


### PR DESCRIPTION
Required follow up of #47 so that the package can be used from an install space.