### PR TITLE
proc/net/unix: Fix bug where an exception would raise when the path has spaces

### DIFF
--- a/src/parsers/unix_socket.cpp
+++ b/src/parsers/unix_socket.cpp
@@ -66,6 +66,7 @@ unix_socket parse_unix_socket_line(const std::string& line)
     // ffff8db2fd23a000: 00000003 00000000 00000000 0001 03 17031 /run/systemd/journal/stdout
     // ffff8db2f696e000: 00000003 00000000 00000000 0001 03 15699 /run/systemd/journal/stdout
     // ffff8db2f3e09400: 00000002 00000000 00000000 0002 01 21401
+    // cad3ab00:         00000003 00000000 00000000 0001 03 7242 /var/qmux_client_socket    401
     // clang-format on
 
     enum token
@@ -83,7 +84,7 @@ unix_socket parse_unix_socket_line(const std::string& line)
     };
 
     auto tokens = utils::split(line);
-    if (tokens.size() < MIN_COUNT || tokens.size() > COUNT)
+    if (tokens.size() < MIN_COUNT)
     {
         throw parser_error(
             "Corrupted unix socket line - Unexpected token count", line);
@@ -107,9 +108,13 @@ unix_socket parse_unix_socket_line(const std::string& line)
 
         utils::stot(tokens[INODE], sock.inode);
 
-        if (tokens.size() > PATH)
+        for (size_t i = PATH; i < tokens.size(); ++i)
         {
-            sock.path = tokens[PATH];
+            sock.path += tokens[i];
+            if (i < tokens.size() - 1)
+            {
+                sock.path += " ";
+            }
         }
 
         return sock;


### PR DESCRIPTION
Socket paths may have spaces (https://unix.stackexchange.com/a/279348),
and since /proc/net/unix parsing is token delimited by space (as it should)

The last parameter should not be delimited by space, but by the end of the line.