### PR TITLE
add function to read task audit session id

### DIFF
--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -96,6 +96,8 @@ public: // Getters
     std::vector<id_map> get_uid_map() const;
     std::vector<id_map> get_gid_map() const;
 
+    uint32_t get_sessionid() const;
+
 private:
     friend class procfs;
     task(const std::string& procfs_root, int id);

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -33,6 +33,7 @@
 #include "pfs/parsers/mountinfo.hpp"
 #include "pfs/parsers/lines.hpp"
 #include "pfs/parsers/common.hpp"
+#include "pfs/parsers/number.hpp"
 #include "pfs/parsers/task_io.hpp"
 #include "pfs/parsers/task_status.hpp"
 #include "pfs/task.hpp"
@@ -487,6 +488,17 @@ std::vector<id_map> task::get_gid_map() const
     parsers::parse_file_lines(path, std::back_inserter(output),
                               parsers::parse_id_map_line);
     return output;
+}
+
+uint32_t task::get_sessionid() const
+{
+    static const std::string SESSION_ID_FILE("sessionid");
+    auto path = _task_root + SESSION_ID_FILE;
+
+    auto line = utils::readline(path);
+    uint32_t session_id;
+    parsers::to_number(line, session_id);
+    return session_id;
 }
 
 } // namespace pfs


### PR DESCRIPTION
Implements #58 

Enables reading Audit Login Session ID of a task (https://www.kernel.org/doc/Documentation/ABI/stable/procfs-audit_loginuid)
