### PR TITLE
Add /proc/smaps parser

### DIFF
--- a/include/pfs/parsers/mem_map.hpp
+++ b/include/pfs/parsers/mem_map.hpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2020-present Daniel Trugman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PFS_PARSERS_MEM_MAP_HPP
+#define PFS_PARSERS_MEM_MAP_HPP
+
+#include <string>
+#include <vector>
+
+#include "pfs/types.hpp"
+
+namespace pfs {
+namespace impl {
+namespace parsers {
+
+std::vector<mem_map> parse_mem_map(const std::string& path);
+
+} // namespace parsers
+} // namespace impl
+} // namespace pfs
+
+#endif // PFS_PARSERS_MEM_MAP_HPP

--- a/include/pfs/parsers/meminfo.hpp
+++ b/include/pfs/parsers/meminfo.hpp
@@ -17,7 +17,6 @@
 #ifndef PFS_PARSERS_MEMINFO_HPP
 #define PFS_PARSERS_MEMINFO_HPP
 
-#include <functional>
 #include <string>
 
 namespace pfs {

--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -69,6 +69,8 @@ public: // Getters
 
     std::vector<mem_region> get_maps() const;
 
+    std::vector<mem_map> get_smaps() const;
+
     mem get_mem() const;
 
     std::vector<mount> get_mountinfo() const;

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -23,7 +23,6 @@
 #include <chrono>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace pfs {

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -339,6 +339,37 @@ struct mem_region
     }
 };
 
+struct mem_map
+{
+    mem_region region;
+
+    size_t size             = 0; // In kB
+    size_t kernel_page_size = 0; // In kB
+    size_t mmu_page_size    = 0; // In kB
+    size_t rss              = 0; // In kB
+    size_t pss              = 0; // In kB
+    size_t pss_dirty        = 0; // In kB
+    size_t shared_clean     = 0; // In kB
+    size_t shared_dirty     = 0; // In kB
+    size_t private_clean    = 0; // In kB
+    size_t private_dirty    = 0; // In kB
+    size_t referenced       = 0; // In kB
+    size_t anonymous        = 0; // In kB
+    size_t ksm              = 0; // In kB
+    size_t lazy_free        = 0; // In kB
+    size_t anon_huge_pages  = 0; // In kB
+    size_t shmem_pmd_mapped = 0; // In kB
+    size_t file_pmd_mapped  = 0; // In kB
+    size_t shared_hugetlb   = 0; // In kB
+    size_t private_hugetlb  = 0; // In kB
+    size_t swap             = 0; // In kB
+    size_t swap_pss         = 0; // In kB
+    size_t locked           = 0; // In kB
+
+    bool thp_eligible       = false;
+    std::string vm_flags;
+};
+
 struct module
 {
     enum class state

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -164,6 +164,9 @@ ip parse_ipv6_address(const std::string& ip_address_hex);
 // Figure out ip version (IPv4/IPv6), parse it and return it as a ip struct
 std::pair<ip, uint16_t> parse_address(const std::string& address_str);
 
+// Parses a memory size line (e.g. VmRSS:      4488 kB)
+void parse_memory_size(const std::string& value, size_t& out);
+
 } // namespace utils
 } // namespace impl
 } // namespace pfs

--- a/src/mem_map.cpp
+++ b/src/mem_map.cpp
@@ -1,0 +1,248 @@
+/*
+ *  Copyright 2020-present Daniel Trugman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fstream>
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "pfs/parser_error.hpp"
+#include "pfs/parsers/maps.hpp"
+#include "pfs/parsers/mem_map.hpp"
+#include "pfs/types.hpp"
+#include "pfs/utils.hpp"
+
+namespace pfs {
+namespace impl {
+namespace parsers {
+
+namespace {
+
+void parse_size(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.size);
+}
+
+void parse_kernel_page_size(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.kernel_page_size);
+}
+
+void parse_mmu_page_size(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.mmu_page_size);
+}
+
+void parse_rss(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.rss);
+}
+
+void parse_pss(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.pss);
+}
+
+void parse_pss_dirty(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.pss_dirty);
+}
+
+void parse_shared_clean(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.shared_clean);
+}
+
+void parse_shared_dirty(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.shared_dirty);
+}
+
+void parse_private_clean(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.private_clean);
+}
+
+void parse_private_dirty(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.private_dirty);
+}
+
+void parse_referenced(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.referenced);
+}
+
+void parse_anonymous(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.anonymous);
+}
+
+void parse_ksm(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.ksm);
+}
+
+void parse_lazy_free(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.lazy_free);
+}
+
+void parse_anon_huge_pages(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.anon_huge_pages);
+}
+
+void parse_shmem_pmd_mapped(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.shmem_pmd_mapped);
+}
+
+void parse_file_pmd_mapped(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.file_pmd_mapped);
+}
+
+void parse_shared_hugetlb(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.shared_hugetlb);
+}
+
+void parse_private_hugetlb(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.private_hugetlb);
+}
+
+void parse_swap(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.swap);
+}
+
+void parse_swap_pss(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.swap_pss);
+}
+
+void parse_locked(const std::string& value, mem_map& out)
+{
+    utils::parse_memory_size(value, out.locked);
+}
+
+void parse_thp_eligible(const std::string& value, mem_map& out)
+{
+    int thp_eligible = 0;
+    utils::stot(value, thp_eligible);
+    out.thp_eligible = thp_eligible != 0;
+}
+
+using value_parser =
+    std::function<void(const std::string& value, mem_map& out)>;
+using value_parsers = std::unordered_map<std::string, value_parser>;
+
+const value_parsers parsers = {{"Size", parse_size},
+                               {"KernelPageSize", parse_kernel_page_size},
+                               {"MMUPageSize", parse_mmu_page_size},
+                               {"Rss", parse_rss},
+                               {"Pss", parse_pss},
+                               {"Pss_Dirty", parse_pss_dirty},
+                               {"Shared_Clean", parse_shared_clean},
+                               {"Shared_Dirty", parse_shared_dirty},
+                               {"Private_Clean", parse_private_clean},
+                               {"Private_Dirty", parse_private_dirty},
+                               {"Referenced", parse_referenced},
+                               {"Anonymous", parse_anonymous},
+                               {"KSM", parse_ksm},
+                               {"LazyFree", parse_lazy_free},
+                               {"AnonHugePages", parse_anon_huge_pages},
+                               {"ShmemPmdMapped", parse_shmem_pmd_mapped},
+                               {"FilePmdMapped", parse_file_pmd_mapped},
+                               {"Shared_Hugetlb", parse_shared_hugetlb},
+                               {"Private_Hugetlb", parse_private_hugetlb},
+                               {"Swap", parse_swap},
+                               {"SwapPss", parse_swap_pss},
+                               {"Locked", parse_locked},
+                               {"THPeligible", parse_thp_eligible}};
+
+} // namespace
+
+std::vector<mem_map> parse_mem_map(const std::string& path)
+{
+    std::ifstream in(path);
+    if (!in)
+    {
+        throw parser_error("Couldn't open file", path);
+    }
+
+    std::vector<mem_map> mem_maps;
+    std::optional<mem_map> current;
+    std::string line;
+    while (std::getline(in, line))
+    {
+        auto tokens = utils::split(line);
+        if (tokens.size() >= 5 && tokens[0] != "VmFlags:")
+        {
+            // Header line
+            if (current)
+            {
+                mem_maps.push_back(std::move(*current));
+            }
+
+            current.emplace();
+            current->region = parse_maps_line(line);
+
+            continue;
+        }
+
+        if (!current)
+        {
+            throw parser_error("Corrupted block - Missing header", line);
+        }
+
+        auto [key, value] = utils::split_once(line, ':');
+        if (key.empty())
+        {
+            throw parser_error("Corrupted line - Missing key", line);
+        }
+
+        utils::rtrim(key);
+        utils::ltrim(value);
+        if (key == "VmFlags")
+        {
+            // TODO: Split this into tokens and parse them?
+            current->vm_flags = value;
+            continue;
+        }
+
+        auto iter = parsers.find(key);
+        if (iter != parsers.end())
+        {
+            auto& parser = iter->second;
+            parser(value, *current);
+        }
+    }
+
+    if (current)
+    {
+        mem_maps.push_back(std::move(*current));
+    }
+
+    return mem_maps;
+}
+
+} // namespace parsers
+} // namespace impl
+} // namespace pfs

--- a/src/parsers/task_status.cpp
+++ b/src/parsers/task_status.cpp
@@ -223,114 +223,84 @@ void parse_ns_sid(const std::string& value, task_status& out)
     to_ns_ids_vector(value, out.ns_sid);
 }
 
-void to_memory_size(const std::string& value, size_t& out)
-{
-    enum token
-    {
-        SIZE  = 0,
-        UNITS = 1,
-        COUNT
-    };
-
-    auto tokens = utils::split(value);
-    if (tokens.size() != COUNT)
-    {
-        throw parser_error("Corrupted memory size - Unexpected tokens count",
-                           value);
-    }
-
-    try
-    {
-        utils::stot(tokens[SIZE], out);
-    }
-    catch (const std::invalid_argument& ex)
-    {
-        throw parser_error("Corrupted memory size - Invalid argument", value);
-    }
-    catch (const std::out_of_range& ex)
-    {
-        throw parser_error("Corrupted memory size - Out of range", value);
-    }
-}
-
 void parse_vm_peak(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_peak);
+    utils::parse_memory_size(value, out.vm_peak);
 }
 
 void parse_vm_size(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_size);
+    utils::parse_memory_size(value, out.vm_size);
 }
 
 void parse_vm_lck(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_lck);
+    utils::parse_memory_size(value, out.vm_lck);
 }
 
 void parse_vm_pin(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_pin);
+    utils::parse_memory_size(value, out.vm_pin);
 }
 
 void parse_vm_hwm(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_hwm);
+    utils::parse_memory_size(value, out.vm_hwm);
 }
 
 void parse_vm_rss(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_rss);
+    utils::parse_memory_size(value, out.vm_rss);
 }
 
 void parse_rss_anon(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.rss_anon);
+    utils::parse_memory_size(value, out.rss_anon);
 }
 
 void parse_rss_file(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.rss_file);
+    utils::parse_memory_size(value, out.rss_file);
 }
 
 void parse_rss_shmem(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.rss_shmem);
+    utils::parse_memory_size(value, out.rss_shmem);
 }
 
 void parse_vm_data(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_data);
+    utils::parse_memory_size(value, out.vm_data);
 }
 
 void parse_vm_stk(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_stk);
+    utils::parse_memory_size(value, out.vm_stk);
 }
 
 void parse_vm_exe(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_exe);
+    utils::parse_memory_size(value, out.vm_exe);
 }
 
 void parse_vm_lib(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_lib);
+    utils::parse_memory_size(value, out.vm_lib);
 }
 
 void parse_vm_pte(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_pte);
+    utils::parse_memory_size(value, out.vm_pte);
 }
 
 void parse_vm_swap(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.vm_swap);
+    utils::parse_memory_size(value, out.vm_swap);
 }
 
 void parse_huge_tlb_pages(const std::string& value, task_status& out)
 {
-    to_memory_size(value, out.huge_tlb_pages);
+    utils::parse_memory_size(value, out.huge_tlb_pages);
 }
 
 void to_boolean(const std::string& value, bool& out)

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -23,8 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <fstream>
-#include <iostream>
 #include <system_error>
 
 #include "pfs/defer.hpp"

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -32,6 +32,7 @@
 #include "pfs/parsers/lines.hpp"
 #include "pfs/parsers/common.hpp"
 #include "pfs/parsers/number.hpp"
+#include "pfs/parsers/mem_map.hpp"
 #include "pfs/parsers/task_io.hpp"
 #include "pfs/parsers/task_status.hpp"
 #include "pfs/task.hpp"
@@ -347,6 +348,14 @@ std::vector<mem_region> task::get_maps() const
     parsers::parse_file_lines(path, std::back_inserter(output),
                               parsers::parse_maps_line);
     return output;
+}
+
+std::vector<mem_map> task::get_smaps() const
+{
+    static const std::string MAPS_FILE("smaps");
+    auto path = _task_root + MAPS_FILE;
+
+    return parsers::parse_mem_map(path);
 }
 
 mem task::get_mem() const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -325,6 +325,36 @@ std::pair<ip, uint16_t> parse_address(const std::string& address_str)
     return std::make_pair(addr, port);
 }
 
+void parse_memory_size(const std::string& value, size_t& out)
+{
+    enum token
+    {
+        SIZE  = 0,
+        UNITS = 1,
+        COUNT
+    };
+
+    auto tokens = utils::split(value);
+    if (tokens.size() != COUNT)
+    {
+        throw parser_error("Corrupted memory size - Unexpected tokens count",
+                           value);
+    }
+
+    try
+    {
+        utils::stot(tokens[SIZE], out);
+    }
+    catch (const std::invalid_argument& ex)
+    {
+        throw parser_error("Corrupted memory size - Invalid argument", value);
+    }
+    catch (const std::out_of_range& ex)
+    {
+        throw parser_error("Corrupted memory size - Out of range", value);
+    }
+}
+
 } // namespace utils
 } // namespace impl
 } // namespace pfs

--- a/test/test_smaps.cpp
+++ b/test/test_smaps.cpp
@@ -1,0 +1,134 @@
+#include "catch.hpp"
+#include "test_utils.hpp"
+
+#include "pfs/parsers/mem_map.hpp"
+
+using namespace pfs::impl::parsers;
+
+TEST_CASE("Parse smaps", "[task][smaps]")
+{
+    // clang-format off
+    std::vector<std::string> content = {
+        // -- First region header --
+        "c0fbeffd0000-c0fbeffe5000 r-xp 00000000 fc:00 1750349                    /usr/lib/systemd/systemd",
+        "Size:                 100 kB",
+        "KernelPageSize:         5 kB",
+        "MMUPageSize:            6 kB",
+        "Rss:                  110 kB",
+        "Pss:                   55 kB",
+        "Pss_Dirty:             10 kB",
+        "Shared_Clean:         120 kB",
+        "Shared_Dirty:           5 kB",
+        "Private_Clean:          15 kB",
+        "Private_Dirty:          20 kB",
+        "Referenced:           130 kB",
+        "Anonymous:             25 kB",
+        "KSM:                    2 kB",
+        "LazyFree:              30 kB",
+        "AnonHugePages:         35 kB",
+        "ShmemPmdMapped:        40 kB",
+        "FilePmdMapped:         45 kB",
+        "Shared_Hugetlb:        50 kB",
+        "Private_Hugetlb:       55 kB",
+        "Swap:                  60 kB",
+        "SwapPss:               65 kB",
+        "Locked:                70 kB",
+        "THPeligible:            1",
+        "VmFlags: rd ex mr mw",
+        // -- Second region header --
+        "fdef41c40000-fdef41c64000 r-xp 00000000 fc:00 1705464                    /usr/lib/aarch64-linux-gnu/libgpg-error.so.0.34.0",
+        "Size:                200 kB",
+        "KernelPageSize:        8 kB",
+        "MMUPageSize:           9 kB",
+        "Rss:                 210 kB",
+        "Pss:                  90 kB",
+        "Pss_Dirty:            15 kB",
+        "Shared_Clean:        220 kB",
+        "Shared_Dirty:          10 kB",
+        "Private_Clean:         30 kB",
+        "Private_Dirty:         40 kB",
+        "Referenced:          230 kB",
+        "Anonymous:             50 kB",
+        "KSM:                    3 kB",
+        "LazyFree:              35 kB",
+        "AnonHugePages:         40 kB",
+        "ShmemPmdMapped:        45 kB",
+        "FilePmdMapped:         50 kB",
+        "Shared_Hugetlb:        55 kB",
+        "Private_Hugetlb:       60 kB",
+        "Swap:                  65 kB",
+        "SwapPss:               70 kB",
+        "Locked:                75 kB",
+        "THPeligible:            0",
+        "VmFlags: rd ex mr mw me"
+    };
+    // clang-format on
+
+    std::string file = create_temp_file(content);
+    pfs::impl::defer unlink_temp_file([&file] { unlink(file.c_str()); });
+
+    SECTION("Parse all maps")
+    {
+        auto smaps = parse_mem_map(file);
+        REQUIRE(smaps.size() == 2);
+
+        REQUIRE(smaps[0].region.start_address == 0xc0fbeffd0000);
+        REQUIRE(smaps[0].region.end_address == 0xc0fbeffe5000);
+        REQUIRE(smaps[0].region.pathname == "/usr/lib/systemd/systemd");
+
+        REQUIRE(smaps[0].size == 100);
+        REQUIRE(smaps[0].kernel_page_size == 5);
+        REQUIRE(smaps[0].mmu_page_size == 6);
+        REQUIRE(smaps[0].rss == 110);
+        REQUIRE(smaps[0].pss == 55);
+        REQUIRE(smaps[0].pss_dirty == 10);
+        REQUIRE(smaps[0].shared_clean == 120);
+        REQUIRE(smaps[0].shared_dirty == 5);
+        REQUIRE(smaps[0].private_clean == 15);
+        REQUIRE(smaps[0].private_dirty == 20);
+        REQUIRE(smaps[0].referenced == 130);
+        REQUIRE(smaps[0].anonymous == 25);
+        REQUIRE(smaps[0].ksm == 2);
+        REQUIRE(smaps[0].lazy_free == 30);
+        REQUIRE(smaps[0].anon_huge_pages == 35);
+        REQUIRE(smaps[0].shmem_pmd_mapped == 40);
+        REQUIRE(smaps[0].file_pmd_mapped == 45);
+        REQUIRE(smaps[0].shared_hugetlb == 50);
+        REQUIRE(smaps[0].private_hugetlb == 55);
+        REQUIRE(smaps[0].swap == 60);
+        REQUIRE(smaps[0].swap_pss == 65);
+        REQUIRE(smaps[0].locked == 70);
+        REQUIRE(smaps[0].thp_eligible == true);
+        REQUIRE(smaps[0].vm_flags == "rd ex mr mw");
+
+        REQUIRE(smaps[1].region.start_address == 0xfdef41c40000);
+        REQUIRE(smaps[1].region.end_address == 0xfdef41c64000);
+        REQUIRE(smaps[1].region.pathname ==
+                "/usr/lib/aarch64-linux-gnu/libgpg-error.so.0.34.0");
+
+        REQUIRE(smaps[1].size == 200);
+        REQUIRE(smaps[1].kernel_page_size == 8);
+        REQUIRE(smaps[1].mmu_page_size == 9);
+        REQUIRE(smaps[1].rss == 210);
+        REQUIRE(smaps[1].pss == 90);
+        REQUIRE(smaps[1].pss_dirty == 15);
+        REQUIRE(smaps[1].shared_clean == 220);
+        REQUIRE(smaps[1].shared_dirty == 10);
+        REQUIRE(smaps[1].private_clean == 30);
+        REQUIRE(smaps[1].private_dirty == 40);
+        REQUIRE(smaps[1].referenced == 230);
+        REQUIRE(smaps[1].anonymous == 50);
+        REQUIRE(smaps[1].ksm == 3);
+        REQUIRE(smaps[1].lazy_free == 35);
+        REQUIRE(smaps[1].anon_huge_pages == 40);
+        REQUIRE(smaps[1].shmem_pmd_mapped == 45);
+        REQUIRE(smaps[1].file_pmd_mapped == 50);
+        REQUIRE(smaps[1].shared_hugetlb == 55);
+        REQUIRE(smaps[1].private_hugetlb == 60);
+        REQUIRE(smaps[1].swap == 65);
+        REQUIRE(smaps[1].swap_pss == 70);
+        REQUIRE(smaps[1].locked == 75);
+        REQUIRE(smaps[1].thp_eligible == false);
+        REQUIRE(smaps[1].vm_flags == "rd ex mr mw me");
+    }
+}


### PR DESCRIPTION
This PR introduces a parser for `/proc/smaps` that converts mapping attributes to a new `mem_map` structure. All standard attributes (e.g. `Size`, `Rss`, etc.) are parsed and converted using our custom utilities. The `VmFlags` attribute is captured as a raw string, with further processing deferred. Comprehensive tests for multiple mapping entries are included.