### PR TITLE
Make ino_t a consistent size

### DIFF
--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -65,7 +65,7 @@ public: // Getters
 
     std::unordered_map<int, fd> get_fds() const;
 
-    std::set<ino_t> get_fds_inodes() const;
+    std::set<pfs_ino_t> get_fds_inodes() const;
 
     std::vector<mem_region> get_maps() const;
 
@@ -75,9 +75,9 @@ public: // Getters
 
     net get_net() const;
 
-    ino_t get_ns(const std::string& ns) const;
+    pfs_ino_t get_ns(const std::string& ns) const;
 
-    std::unordered_map<std::string, ino_t> get_ns() const;
+    std::unordered_map<std::string, pfs_ino_t> get_ns() const;
 
     std::string get_root() const;
 

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -28,9 +28,11 @@
 
 namespace pfs {
 
+typedef uint64_t pfs_ino_t;
+
 constexpr uid_t INVALID_UID   = (uid_t)-1;
 constexpr pid_t INVALID_PID   = (pid_t)-1;
-constexpr ino_t INVALID_INODE = (ino_t)0;
+constexpr pfs_ino_t INVALID_INODE = (pfs_ino_t)0;
 
 // Note: We only support values that exist post 2.6.32.
 enum class task_state
@@ -331,7 +333,7 @@ struct mem_region
     mem_perm perm;
     size_t offset = 0;
     dev_t device  = 0;
-    ino_t inode   = INVALID_INODE;
+    pfs_ino_t inode   = INVALID_INODE;
     std::string pathname;
 
     bool operator<(const mem_region& rhs) const
@@ -522,7 +524,7 @@ struct net_socket
     size_t retransmits;
     uid_t uid;
     size_t timeouts;
-    ino_t inode;
+    pfs_ino_t inode;
     int ref_count;
     size_t skbuff;
 
@@ -560,7 +562,7 @@ struct unix_socket
     int flags;
     type socket_type;
     state socket_state;
-    ino_t inode;
+    pfs_ino_t inode;
     std::string path;
 
     bool operator<(const unix_socket& rhs) const
@@ -580,7 +582,7 @@ struct netlink_socket
     bool dumping     = false;
     int ref_count    = 0;
     unsigned drops   = 0;
-    ino_t inode      = INVALID_INODE;
+    pfs_ino_t inode      = INVALID_INODE;
 
     bool operator<(const unix_socket& rhs) const
     {

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -111,7 +111,7 @@ std::set<int> enumerate_numeric_files(const std::string& dir);
 // Get the inode number of the file.
 // If the linkname is relative, then it is interpreted relative to the directory
 // referred to by the file descriptor dirfd.
-ino_t get_inode(const std::string& path, int dirfd = AT_FDCWD);
+pfs_ino_t get_inode(const std::string& path, int dirfd = AT_FDCWD);
 
 // Return the path to which the specified link points.
 // If the linkname is relative, then it is interpreted relative to the directory

--- a/sample/enum_fd.cpp
+++ b/sample/enum_fd.cpp
@@ -22,7 +22,7 @@
 
 template <typename T>
 void add_sockets(const std::vector<T>& sockets,
-                 std::unordered_map<ino_t, std::string>& output)
+                 std::unordered_map<pfs::pfs_ino_t, std::string>& output)
 {
     for (auto& socket : sockets)
     {
@@ -32,9 +32,9 @@ void add_sockets(const std::vector<T>& sockets,
     }
 }
 
-std::unordered_map<ino_t, std::string> enum_sockets(const pfs::net& net)
+std::unordered_map<pfs::pfs_ino_t, std::string> enum_sockets(const pfs::net& net)
 {
-    std::unordered_map<ino_t, std::string> sockets;
+    std::unordered_map<pfs::pfs_ino_t, std::string> sockets;
     add_sockets(net.get_icmp(), sockets);
     add_sockets(net.get_icmp6(), sockets);
     add_sockets(net.get_raw(), sockets);

--- a/src/parsers/maps.cpp
+++ b/src/parsers/maps.cpp
@@ -114,11 +114,11 @@ size_t parse_mem_region_offset(const std::string& offset_str)
     }
 }
 
-ino_t parse_mem_region_inode(const std::string& inode_str)
+pfs_ino_t parse_mem_region_inode(const std::string& inode_str)
 {
     try
     {
-        ino_t inode;
+        pfs_ino_t inode;
         utils::stot(inode_str, inode);
         return inode;
     }

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -392,9 +392,9 @@ std::unordered_map<int, fd> task::get_fds() const
     return fds;
 }
 
-std::set<ino_t> task::get_fds_inodes() const
+std::set<pfs_ino_t> task::get_fds_inodes() const
 {
-    std::set<ino_t> inodes;
+    std::set<pfs_ino_t> inodes;
 
     for (auto& fd : get_fds())
     {
@@ -409,7 +409,7 @@ net task::get_net() const
     return net(_task_root);
 }
 
-ino_t task::get_ns(const std::string& ns) const
+pfs_ino_t task::get_ns(const std::string& ns) const
 {
     static const std::string NS_DIR("ns/");
     auto path = _task_root + NS_DIR + ns;
@@ -417,7 +417,7 @@ ino_t task::get_ns(const std::string& ns) const
     return utils::get_inode(path);
 }
 
-std::unordered_map<std::string, ino_t> task::get_ns() const
+std::unordered_map<std::string, pfs_ino_t> task::get_ns() const
 {
     static const std::string NS_DIR("ns/");
     auto path = _task_root + NS_DIR;
@@ -430,7 +430,7 @@ std::unordered_map<std::string, ino_t> task::get_ns() const
     }
     defer close_dirfd([dirfd] { close(dirfd); });
 
-    std::unordered_map<std::string, ino_t> ns;
+    std::unordered_map<std::string, pfs_ino_t> ns;
 
     for (const auto& file :
          utils::enumerate_files(path, /* include_dots */ false))

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -102,7 +102,7 @@ std::set<int> enumerate_numeric_files(const std::string& dir)
     return files;
 }
 
-ino_t get_inode(const std::string& path, int dirfd)
+pfs_ino_t get_inode(const std::string& path, int dirfd)
 {
     struct stat st;
     int err = fstatat(dirfd, path.c_str(), &st, 0);

--- a/test/test_maps.cpp
+++ b/test/test_maps.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Parse maps", "[task][maps]")
     dev_t dev_major;
     dev_t dev_minor;
 
-    ino_t inode;
+    pfs::pfs_ino_t inode;
 
     std::string pathname;
 


### PR DESCRIPTION
Proposed fix for #48 

Effectively this just introduces a new type (`pfs::pfs_ino_t`) that is used instead of `ino_t` so that it is always the same size, no matter if `ino_t` is 32 bits or 64 bits.

This might break some current code due to the type changing and the size(number of bits) of the type changing.

I've done some minimal testing on my side