### PR TITLE
Support qmux socket paths

### DIFF
--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -541,7 +541,11 @@ struct unix_socket
     {
         stream    = 1,
         datagram  = 2,
+        raw       = 3,
+        rdm       = 4,
         seqpacket = 5,
+        dccp      = 6,
+        packet    = 10,
     };
 
     // See the Kerne's 'socket_state' enum for more information

--- a/src/parsers/unix_socket.cpp
+++ b/src/parsers/unix_socket.cpp
@@ -18,6 +18,9 @@
 #include "pfs/parser_error.hpp"
 #include "pfs/utils.hpp"
 
+#include <iostream>
+using namespace std;
+
 namespace pfs {
 namespace impl {
 namespace parsers {
@@ -66,6 +69,7 @@ unix_socket parse_unix_socket_line(const std::string& line)
     // ffff8db2fd23a000: 00000003 00000000 00000000 0001 03 17031 /run/systemd/journal/stdout
     // ffff8db2f696e000: 00000003 00000000 00000000 0001 03 15699 /run/systemd/journal/stdout
     // ffff8db2f3e09400: 00000002 00000000 00000000 0002 01 21401
+    // cad3ab00:         00000003 00000000 00000000 0001 03 7242 /var/qmux_client_socket    401
     // clang-format on
 
     enum token
@@ -83,7 +87,7 @@ unix_socket parse_unix_socket_line(const std::string& line)
     };
 
     auto tokens = utils::split(line);
-    if (tokens.size() < MIN_COUNT || tokens.size() > COUNT)
+    if (tokens.size() < MIN_COUNT)
     {
         throw parser_error(
             "Corrupted unix socket line - Unexpected token count", line);
@@ -107,9 +111,9 @@ unix_socket parse_unix_socket_line(const std::string& line)
 
         utils::stot(tokens[INODE], sock.inode);
 
-        if (tokens.size() > PATH)
-        {
-            sock.path = tokens[PATH];
+        if (tokens.size() > PATH) {
+            size_t path_start = line.find(tokens[PATH]);
+            sock.path = line.substr(path_start);
         }
 
         return sock;

--- a/test/test_unix_socket.cpp
+++ b/test/test_unix_socket.cpp
@@ -87,6 +87,23 @@ TEST_CASE("Parse unix socket", "[net][unix_socket]")
         expected.path         = "@/org/kernel/udev/udevd";
     }
 
+    SECTION("Qmux socket")
+    {
+        size_t skbuff = 0xcad3ab00;
+
+        line << skbuff << ":         00000003 00000000 00000000 0001 03 "
+                "7242 /var/qmux_client_socket    401";
+
+        expected.skbuff       = skbuff;
+        expected.ref_count    = 0x00000003;
+        expected.protocol     = 0x00000000;
+        expected.flags        = 0x00000000;
+        expected.socket_type  = pfs::unix_socket::type::stream;
+        expected.socket_state = pfs::unix_socket::state::connected;
+        expected.inode        = 7242;
+        expected.path         = "/var/qmux_client_socket    401";
+    }
+
     auto socket = parse_unix_socket_line(line.str());
     REQUIRE(socket.skbuff == expected.skbuff);
     REQUIRE(socket.ref_count == expected.ref_count);


### PR DESCRIPTION
qmux socket paths might have an extra number at the end of the line:
```
// cad3ab00:         00000003 00000000 00000000 0001 03 7242 /var/qmux_client_socket    401
```

Make sure the parser handles that correctly.