### PR TITLE
Use 64 bit types instead of ino_t and size_t

### DIFF
--- a/docker/Dockerfile-debian12-32bit
+++ b/docker/Dockerfile-debian12-32bit
@@ -1,0 +1,11 @@
+FROM arm32v7/debian:bookworm
+
+WORKDIR /pfs
+
+RUN apt-get update && \
+    apt-get install -y cmake g++ build-essential
+
+ENV CXX=g++
+ENV CC=gcc
+
+CMD /bin/bash

--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -65,7 +65,7 @@ public: // Getters
 
     std::unordered_map<int, fd> get_fds() const;
 
-    std::set<ino_t> get_fds_inodes() const;
+    std::set<ino64_t> get_fds_inodes() const;
 
     std::vector<mem_region> get_maps() const;
 
@@ -77,9 +77,9 @@ public: // Getters
 
     net get_net() const;
 
-    ino_t get_ns(const std::string& ns) const;
+    ino64_t get_ns(const std::string& ns) const;
 
-    std::unordered_map<std::string, ino_t> get_ns() const;
+    std::unordered_map<std::string, ino64_t> get_ns() const;
 
     std::string get_root() const;
 

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -265,22 +265,22 @@ struct task_status
     std::vector<pid_t> ns_pid;
     std::vector<pid_t> ns_pgid;
     std::vector<pid_t> ns_sid;
-    size_t vm_peak                  = 0; // In kB
-    size_t vm_size                  = 0; // In kB
-    size_t vm_lck                   = 0; // In kB
-    size_t vm_pin                   = 0; // In kB
-    size_t vm_hwm                   = 0; // In kB
-    size_t vm_rss                   = 0; // In kB
-    size_t rss_anon                 = 0; // In kB
-    size_t rss_file                 = 0; // In kB
-    size_t rss_shmem                = 0; // In kB
-    size_t vm_data                  = 0; // In kB
-    size_t vm_stk                   = 0; // In kB
-    size_t vm_exe                   = 0; // In kB
-    size_t vm_lib                   = 0; // In kB
-    size_t vm_pte                   = 0; // In kB
-    size_t vm_swap                  = 0; // In kB
-    size_t huge_tlb_pages           = 0; // In kB
+    uint64_t vm_peak                  = 0; // In kB
+    uint64_t vm_size                  = 0; // In kB
+    uint64_t vm_lck                   = 0; // In kB
+    uint64_t vm_pin                   = 0; // In kB
+    uint64_t vm_hwm                   = 0; // In kB
+    uint64_t vm_rss                   = 0; // In kB
+    uint64_t rss_anon                 = 0; // In kB
+    uint64_t rss_file                 = 0; // In kB
+    uint64_t rss_shmem                = 0; // In kB
+    uint64_t vm_data                  = 0; // In kB
+    uint64_t vm_stk                   = 0; // In kB
+    uint64_t vm_exe                   = 0; // In kB
+    uint64_t vm_lib                   = 0; // In kB
+    uint64_t vm_pte                   = 0; // In kB
+    uint64_t vm_swap                  = 0; // In kB
+    uint64_t huge_tlb_pages           = 0; // In kB
     bool core_dumping               = false;
     size_t threads                  = 1;
     std::pair<size_t, size_t> sig_q = {0, 0};
@@ -325,8 +325,8 @@ struct mem_perm
 
 struct mem_region
 {
-    size_t start_address = 0;
-    size_t end_address   = 0;
+    uint64_t start_address = 0;
+    uint64_t end_address   = 0;
     mem_perm perm;
     size_t offset = 0;
     dev_t device  = 0;
@@ -343,28 +343,28 @@ struct mem_map
 {
     mem_region region;
 
-    size_t size             = 0; // In kB
-    size_t kernel_page_size = 0; // In kB
-    size_t mmu_page_size    = 0; // In kB
-    size_t rss              = 0; // In kB
-    size_t pss              = 0; // In kB
-    size_t pss_dirty        = 0; // In kB
-    size_t shared_clean     = 0; // In kB
-    size_t shared_dirty     = 0; // In kB
-    size_t private_clean    = 0; // In kB
-    size_t private_dirty    = 0; // In kB
-    size_t referenced       = 0; // In kB
-    size_t anonymous        = 0; // In kB
-    size_t ksm              = 0; // In kB
-    size_t lazy_free        = 0; // In kB
-    size_t anon_huge_pages  = 0; // In kB
-    size_t shmem_pmd_mapped = 0; // In kB
-    size_t file_pmd_mapped  = 0; // In kB
-    size_t shared_hugetlb   = 0; // In kB
-    size_t private_hugetlb  = 0; // In kB
-    size_t swap             = 0; // In kB
-    size_t swap_pss         = 0; // In kB
-    size_t locked           = 0; // In kB
+    uint64_t size             = 0; // In kB
+    uint64_t kernel_page_size = 0; // In kB
+    uint64_t mmu_page_size    = 0; // In kB
+    uint64_t rss              = 0; // In kB
+    uint64_t pss              = 0; // In kB
+    uint64_t pss_dirty        = 0; // In kB
+    uint64_t shared_clean     = 0; // In kB
+    uint64_t shared_dirty     = 0; // In kB
+    uint64_t private_clean    = 0; // In kB
+    uint64_t private_dirty    = 0; // In kB
+    uint64_t referenced       = 0; // In kB
+    uint64_t anonymous        = 0; // In kB
+    uint64_t ksm              = 0; // In kB
+    uint64_t lazy_free        = 0; // In kB
+    uint64_t anon_huge_pages  = 0; // In kB
+    uint64_t shmem_pmd_mapped = 0; // In kB
+    uint64_t file_pmd_mapped  = 0; // In kB
+    uint64_t shared_hugetlb   = 0; // In kB
+    uint64_t private_hugetlb  = 0; // In kB
+    uint64_t swap             = 0; // In kB
+    uint64_t swap_pss         = 0; // In kB
+    uint64_t locked           = 0; // In kB
 
     bool thp_eligible       = false;
     std::vector<std::string> vm_flags;

--- a/include/pfs/types.hpp
+++ b/include/pfs/types.hpp
@@ -27,9 +27,9 @@
 
 namespace pfs {
 
-constexpr uid_t INVALID_UID   = (uid_t)-1;
-constexpr pid_t INVALID_PID   = (pid_t)-1;
-constexpr ino_t INVALID_INODE = (ino_t)0;
+constexpr uid_t   INVALID_UID   = (uid_t)-1;
+constexpr pid_t   INVALID_PID   = (pid_t)-1;
+constexpr ino64_t INVALID_INODE = (ino64_t)0;
 
 // Note: We only support values that exist post 2.6.32.
 enum class task_state
@@ -330,7 +330,7 @@ struct mem_region
     mem_perm perm;
     size_t offset = 0;
     dev_t device  = 0;
-    ino_t inode   = INVALID_INODE;
+    ino64_t inode = INVALID_INODE;
     std::string pathname;
 
     bool operator<(const mem_region& rhs) const
@@ -552,7 +552,7 @@ struct net_socket
     size_t retransmits;
     uid_t uid;
     size_t timeouts;
-    ino_t inode;
+    ino64_t inode;
     int ref_count;
     size_t skbuff;
 
@@ -594,7 +594,7 @@ struct unix_socket
     int flags;
     type socket_type;
     state socket_state;
-    ino_t inode;
+    ino64_t inode;
     std::string path;
 
     bool operator<(const unix_socket& rhs) const
@@ -614,7 +614,7 @@ struct netlink_socket
     bool dumping     = false;
     int ref_count    = 0;
     unsigned drops   = 0;
-    ino_t inode      = INVALID_INODE;
+    ino64_t inode    = INVALID_INODE;
 
     bool operator<(const unix_socket& rhs) const
     {

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -111,7 +111,7 @@ std::set<int> enumerate_numeric_files(const std::string& dir);
 // Get the inode number of the file.
 // If the linkname is relative, then it is interpreted relative to the directory
 // referred to by the file descriptor dirfd.
-ino_t get_inode(const std::string& path, int dirfd = AT_FDCWD);
+ino64_t get_inode(const std::string& path, int dirfd = AT_FDCWD);
 
 // Return the path to which the specified link points.
 // If the linkname is relative, then it is interpreted relative to the directory

--- a/include/pfs/utils.hpp
+++ b/include/pfs/utils.hpp
@@ -165,7 +165,7 @@ ip parse_ipv6_address(const std::string& ip_address_hex);
 std::pair<ip, uint16_t> parse_address(const std::string& address_str);
 
 // Parses a memory size line (e.g. VmRSS:      4488 kB)
-void parse_memory_size(const std::string& value, size_t& out);
+void parse_memory_size(const std::string& value, uint64_t& out);
 
 } // namespace utils
 } // namespace impl

--- a/sample/enum_fd.cpp
+++ b/sample/enum_fd.cpp
@@ -22,7 +22,7 @@
 
 template <typename T>
 void add_sockets(const std::vector<T>& sockets,
-                 std::unordered_map<ino_t, std::string>& output)
+                 std::unordered_map<ino64_t, std::string>& output)
 {
     for (auto& socket : sockets)
     {
@@ -32,9 +32,9 @@ void add_sockets(const std::vector<T>& sockets,
     }
 }
 
-std::unordered_map<ino_t, std::string> enum_sockets(const pfs::net& net)
+std::unordered_map<ino64_t, std::string> enum_sockets(const pfs::net& net)
 {
-    std::unordered_map<ino_t, std::string> sockets;
+    std::unordered_map<ino64_t, std::string> sockets;
     add_sockets(net.get_icmp(), sockets);
     add_sockets(net.get_icmp6(), sockets);
     add_sockets(net.get_raw(), sockets);

--- a/src/parsers/maps.cpp
+++ b/src/parsers/maps.cpp
@@ -25,7 +25,7 @@ namespace parsers {
 
 namespace {
 
-std::pair<size_t, size_t>
+std::pair<uint64_t, uint64_t>
 parse_mem_region_address(const std::string& address_str)
 {
     // Address must be a range '<start>-<end>'
@@ -47,10 +47,10 @@ parse_mem_region_address(const std::string& address_str)
 
     try
     {
-        size_t start;
+        uint64_t start;
         utils::stot(tokens[START], start, utils::base::hex);
 
-        size_t end;
+        uint64_t end;
         utils::stot(tokens[END], end, utils::base::hex);
 
         return std::make_pair(start, end);
@@ -96,11 +96,11 @@ mem_perm parse_mem_region_permissions(const std::string& perm_str)
     return perm;
 }
 
-size_t parse_mem_region_offset(const std::string& offset_str)
+uint64_t parse_mem_region_offset(const std::string& offset_str)
 {
     try
     {
-        size_t offset;
+        uint64_t offset;
         utils::stot(offset_str, offset, utils::base::hex);
         return offset;
     }

--- a/src/parsers/maps.cpp
+++ b/src/parsers/maps.cpp
@@ -114,11 +114,11 @@ size_t parse_mem_region_offset(const std::string& offset_str)
     }
 }
 
-ino_t parse_mem_region_inode(const std::string& inode_str)
+ino64_t parse_mem_region_inode(const std::string& inode_str)
 {
     try
     {
-        ino_t inode;
+        ino64_t inode;
         utils::stot(inode_str, inode);
         return inode;
     }

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -399,9 +399,9 @@ std::unordered_map<int, fd> task::get_fds() const
     return fds;
 }
 
-std::set<ino_t> task::get_fds_inodes() const
+std::set<ino64_t> task::get_fds_inodes() const
 {
-    std::set<ino_t> inodes;
+    std::set<ino64_t> inodes;
 
     for (auto& fd : get_fds())
     {
@@ -416,7 +416,7 @@ net task::get_net() const
     return net(_task_root);
 }
 
-ino_t task::get_ns(const std::string& ns) const
+ino64_t task::get_ns(const std::string& ns) const
 {
     static const std::string NS_DIR("ns/");
     auto path = _task_root + NS_DIR + ns;
@@ -424,7 +424,7 @@ ino_t task::get_ns(const std::string& ns) const
     return utils::get_inode(path);
 }
 
-std::unordered_map<std::string, ino_t> task::get_ns() const
+std::unordered_map<std::string, ino64_t> task::get_ns() const
 {
     static const std::string NS_DIR("ns/");
     auto path = _task_root + NS_DIR;
@@ -437,7 +437,7 @@ std::unordered_map<std::string, ino_t> task::get_ns() const
     }
     defer close_dirfd([dirfd] { close(dirfd); });
 
-    std::unordered_map<std::string, ino_t> ns;
+    std::unordered_map<std::string, ino64_t> ns;
 
     for (const auto& file :
          utils::enumerate_files(path, /* include_dots */ false))

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -325,7 +325,7 @@ std::pair<ip, uint16_t> parse_address(const std::string& address_str)
     return std::make_pair(addr, port);
 }
 
-void parse_memory_size(const std::string& value, size_t& out)
+void parse_memory_size(const std::string& value, uint64_t& out)
 {
     enum token
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -102,7 +102,7 @@ std::set<int> enumerate_numeric_files(const std::string& dir)
     return files;
 }
 
-ino_t get_inode(const std::string& path, int dirfd)
+ino64_t get_inode(const std::string& path, int dirfd)
 {
     struct stat st;
     int err = fstatat(dirfd, path.c_str(), &st, 0);

--- a/test/test_maps.cpp
+++ b/test/test_maps.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Parse maps", "[task][maps]")
     dev_t dev_major;
     dev_t dev_minor;
 
-    ino_t inode;
+    ino64_t inode;
 
     std::string pathname;
 


### PR DESCRIPTION
When compiling into a 32-bit binary and running on a 64-bit system, the process should be able to represent the entire memory space.
Hence, use 64bit variables instead of the system native ones.