### PR TITLE
Add comments to magic constants missing context

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -42,7 +42,7 @@ std::vector<net_device> net::get_dev(net_device_filter filter) const
     static const std::string DEV_FILE("dev");
     auto path = _net_root + DEV_FILE;
 
-    static const size_t HEADER_LINES = 2;
+    static const size_t HEADER_LINES = 2; // /proc/net/dev has two header rows: title + column names
 
     std::vector<net_device> output;
     parsers::parse_file_lines(path, std::back_inserter(output),

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -60,7 +60,7 @@ bool task::operator<(const task& rhs) const
 
 bool task::is_kernel_thread(const task_stat& st)
 {
-    static const int ROOT_KERNEL_TASK_ID = 2;
+    static const int ROOT_KERNEL_TASK_ID = 2; // kthreadd, parent of all kernel threads
 
     return st.pid == ROOT_KERNEL_TASK_ID || st.ppid == ROOT_KERNEL_TASK_ID;
 }


### PR DESCRIPTION
ROOT_KERNEL_TASK_ID = 2: note that PID 2 is kthreadd, parent of all kernel threads. HEADER_LINES = 2 in get_dev(): note that /proc/net/dev has two header rows (title + column names), distinguishing it from all other net files which have one. All other named constants in the parsers already carry sufficient context.