### PR TITLE
Add optional filter to get_processes() and get_tasks()

### DIFF
--- a/include/pfs/procfs.hpp
+++ b/include/pfs/procfs.hpp
@@ -45,7 +45,7 @@ public:
 
 public: // Task API
     task get_task(int task_id = getpid()) const;
-    std::set<task> get_processes() const;
+    std::set<task> get_processes(task::task_filter filter = nullptr) const;
 
 public: // Network API
     net get_net(int task_id = getpid()) const;

--- a/include/pfs/task.hpp
+++ b/include/pfs/task.hpp
@@ -17,12 +17,14 @@
 #ifndef PFS_TASK_HPP
 #define PFS_TASK_HPP
 
+#include <functional>
 #include <set>
 #include <stddef.h>
 #include <string>
 #include <vector>
 
 #include "fd.hpp"
+#include "filter.hpp"
 #include "mem.hpp"
 #include "net.hpp"
 #include "types.hpp"
@@ -39,6 +41,9 @@ public:
     task& operator=(task&&) = delete;
 
     bool operator<(const task& rhs) const;
+
+public: // Filter types
+    using task_filter = std::function<filter::action(const task&)>;
 
 public: // Static utilities
     static bool is_kernel_thread(const task_stat& st);
@@ -95,7 +100,7 @@ public: // Getters
 
     task get_task(int id) const;
 
-    std::set<task> get_tasks() const;
+    std::set<task> get_tasks(task_filter filter = nullptr) const;
 
     std::vector<id_map> get_uid_map() const;
     std::vector<id_map> get_gid_map() const;

--- a/src/procfs.cpp
+++ b/src/procfs.cpp
@@ -71,12 +71,16 @@ task procfs::get_task(int task_id) const
     return task(_root, task_id);
 }
 
-std::set<task> procfs::get_processes() const
+std::set<task> procfs::get_processes(task::task_filter filter) const
 {
     std::set<task> tasks;
     for (auto task_id : utils::enumerate_numeric_files(_root))
     {
-        tasks.emplace(get_task(task_id));
+        auto t = get_task(task_id);
+        if (!filter || filter(t) == filter::action::keep)
+        {
+            tasks.emplace(std::move(t));
+        }
     }
 
     return tasks;

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -473,7 +473,7 @@ task task::get_task(int id) const
     return task(path, id);
 }
 
-std::set<task> task::get_tasks() const
+std::set<task> task::get_tasks(task_filter filter) const
 {
     static const std::string TASKS_DIR("task/");
     auto path = _task_root + TASKS_DIR;
@@ -484,7 +484,11 @@ std::set<task> task::get_tasks() const
     {
         // Important, see README note about collecting information
         // about threads to understand why we pass 'path' as the root dir.
-        threads.emplace(task(path, thread_id));
+        task t(path, thread_id);
+        if (!filter || filter(t) == filter::action::keep)
+        {
+            threads.emplace(std::move(t));
+        }
     }
 
     return threads;

--- a/test/test_procfs.cpp
+++ b/test/test_procfs.cpp
@@ -1,0 +1,58 @@
+#include <unistd.h>
+
+#include "catch.hpp"
+
+#include "pfs/procfs.hpp"
+
+TEST_CASE("get_processes without filter returns all processes", "[procfs][filter]")
+{
+    auto all     = pfs::procfs().get_processes();
+    auto own_pid = getpid();
+
+    // The current process must appear in the full list
+    auto it = std::find_if(all.begin(), all.end(),
+                           [own_pid](const pfs::task& t) {
+                               return t.id() == own_pid;
+                           });
+    REQUIRE(it != all.end());
+}
+
+TEST_CASE("get_processes with drop-all filter returns empty set", "[procfs][filter]")
+{
+    auto drop_all = [](const pfs::task&) { return pfs::filter::action::drop; };
+    auto result   = pfs::procfs().get_processes(drop_all);
+    REQUIRE(result.empty());
+}
+
+TEST_CASE("get_processes with keep-self filter returns only current process", "[procfs][filter]")
+{
+    auto own_pid  = getpid();
+    auto keep_self = [own_pid](const pfs::task& t) {
+        return t.id() == own_pid ? pfs::filter::action::keep
+                                 : pfs::filter::action::drop;
+    };
+
+    auto result = pfs::procfs().get_processes(keep_self);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result.begin()->id() == own_pid);
+}
+
+TEST_CASE("get_tasks without filter returns all threads", "[task][filter]")
+{
+    auto self    = pfs::procfs().get_task();
+    auto all     = self.get_tasks();
+    auto own_tid = getpid(); // main thread tid == pid
+
+    auto it = std::find_if(all.begin(), all.end(),
+                           [own_tid](const pfs::task& t) {
+                               return t.id() == own_tid;
+                           });
+    REQUIRE(it != all.end());
+}
+
+TEST_CASE("get_tasks with drop-all filter returns empty set", "[task][filter]")
+{
+    auto drop_all = [](const pfs::task&) { return pfs::filter::action::drop; };
+    auto result   = pfs::procfs().get_task().get_tasks(drop_all);
+    REQUIRE(result.empty());
+}


### PR DESCRIPTION
Mirrors the filter pattern already used throughout the net API. Defines task::task_filter as std::function<filter::action(const task&)> in task.hpp and threads it through procfs::get_processes() and task::get_tasks(). Both default to nullptr (no filtering), so existing callers are unaffected. Adds test_procfs.cpp with five live tests covering the unfiltered, drop-all, and keep-self cases.